### PR TITLE
Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/tasklist-template.md
+++ b/.github/ISSUE_TEMPLATE/tasklist-template.md
@@ -1,0 +1,28 @@
+---
+name: TaskList Template
+about: Template for issues created off tasklists
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+## Short description
+
+<!-- Describe the scope of the ticket, a high-level implementation approach and any tradeoffs to consider -->
+
+## Acceptance criteria
+
+<!-- What is the definition of done for this ticket? Include any relevant edge cases and/or test cases -->
+
+## Suggested Tests
+
+<!-- Provide scenarios to test. Link to existing similar tests if appropriate. -->
+
+## Impact to Other Teams
+
+<!-- Will this change impact other teams?  Include details of the kinds of changes required (new tests, code changes, related tickets) and _add the relevant `Impact:[team]` label_. -->
+
+## Context
+
+<!-- Provide the "why", motivation, and alternative approaches considered -- linking to previous refinement issues, spikes, docs as appropriate -->


### PR DESCRIPTION
The first PR missed metadata needed for the slash command to recognize the template.  It's still needed because the metadata cannot be added to yaml files so we need a specific `.md` file for this case.

Proved out it would work [here](https://github.com/emmyoop/action_testing/blob/main/.github/ISSUE_TEMPLATE/tasklist-template.md?plain=1)