### PR TITLE
fix merge group sha

### DIFF
--- a/.github/workflows/ci_dbt_core_testing.yml
+++ b/.github/workflows/ci_dbt_core_testing.yml
@@ -94,7 +94,7 @@ jobs:
           if [[ -z "${{ inputs.dbt-common-ref }}" ]]; then
             # these will be commits instead of branches
             if [[ "${{ github.event_name }}" == "merge_group" ]]; then
-              REF=${{ github.event.pull_request.merge_commit_sha }}
+              REF=${{ github.event.merge_group.head_sha }}
             else
               REF=${{ github.event.pull_request.base.sha }}
             fi


### PR DESCRIPTION
resolves #67 

### Description

There was a bug with the sha referenced for the merge-queue.  This makes it the correct sha.

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-common/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-common/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
 
