### PR TITLE
Make invocation contexts more reliable in testing scenarios.

### DIFF
--- a/.changes/unreleased/Fixes-20240206-160231.yaml
+++ b/.changes/unreleased/Fixes-20240206-160231.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Make invocation contexts more reliable in testing scenarios.
+time: 2024-02-06T16:02:31.81842-05:00
+custom:
+  Author: peterallenwebb
+  Issue: "52"

--- a/dbt_common/context.py
+++ b/dbt_common/context.py
@@ -1,4 +1,4 @@
-from contextvars import ContextVar
+from contextvars import ContextVar, copy_context
 from typing import List, Mapping, Optional
 
 from dbt_common.constants import SECRET_ENV_PREFIX
@@ -26,10 +26,23 @@ class InvocationContext:
 _INVOCATION_CONTEXT_VAR: ContextVar[InvocationContext] = ContextVar("DBT_INVOCATION_CONTEXT_VAR")
 
 
+def _reliably_get_invocation_var() -> ContextVar:
+    invocation_var: Optional[ContextVar] = next(
+        (cv for cv in copy_context() if cv.name == _INVOCATION_CONTEXT_VAR.name), None
+    )
+
+    if invocation_var is None:
+        invocation_var = _INVOCATION_CONTEXT_VAR
+
+    return invocation_var
+
+
 def set_invocation_context(env: Mapping[str, str]) -> None:
-    _INVOCATION_CONTEXT_VAR.set(InvocationContext(env))
+    invocation_var = _reliably_get_invocation_var()
+    invocation_var.set(InvocationContext(env))
 
 
 def get_invocation_context() -> InvocationContext:
-    ctx = _INVOCATION_CONTEXT_VAR.get()
+    invocation_var = _reliably_get_invocation_var()
+    ctx = invocation_var.get()
     return ctx


### PR DESCRIPTION
resolves #52

### Description

Pytest uses some fancy async mechanisms in a way that meant the ContextVar object used to implement InvocationContext access was sometime created more than once. These changes refer to the variable by name rather than object identity, in order to avoid that issue.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-common/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-common/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
 
