### PR TITLE
Fix unset_contextvars to correctly unset the context vars

### DIFF
--- a/.changes/unreleased/Fixes-20240221-200204.yaml
+++ b/.changes/unreleased/Fixes-20240221-200204.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix the unset_contextvars function in events/contextvars.py
+time: 2024-02-21T20:02:04.341681-05:00
+custom:
+  Author: gshank
+  Issue: "82"

--- a/dbt_common/events/contextvars.py
+++ b/dbt_common/events/contextvars.py
@@ -58,12 +58,12 @@ def set_task_contextvars(**kwargs: Any) -> Mapping[str, contextvars.Token]:
 def set_contextvars(prefix: str, **kwargs: Any) -> Mapping[str, contextvars.Token]:
     cvar_tokens = {}
     for k, v in kwargs.items():
-        log_key = f"{prefix}{k}"
+        prefix_key = f"{prefix}{k}"
         try:
-            var = _context_vars[log_key]
+            var = _context_vars[prefix_key]
         except KeyError:
-            var = contextvars.ContextVar(log_key, default=Ellipsis)
-            _context_vars[log_key] = var
+            var = contextvars.ContextVar(prefix_key, default=Ellipsis)
+            _context_vars[prefix_key] = var
 
         cvar_tokens[k] = var.set(v)
 
@@ -73,17 +73,17 @@ def set_contextvars(prefix: str, **kwargs: Any) -> Mapping[str, contextvars.Toke
 # reset by Tokens
 def reset_contextvars(prefix: str, **kwargs: contextvars.Token) -> None:
     for k, v in kwargs.items():
-        log_key = f"{prefix}{k}"
-        var = _context_vars[log_key]
+        prefix_key = f"{prefix}{k}"
+        var = _context_vars[prefix_key]
         var.reset(v)
 
 
 # remove from contextvars
 def unset_contextvars(prefix: str, *keys: str) -> None:
     for k in keys:
-        if k in _context_vars:
-            log_key = f"{prefix}{k}"
-            _context_vars[log_key].set(Ellipsis)
+        prefix_key = f"{prefix}{k}"
+        if prefix_key in _context_vars:
+            _context_vars[prefix_key].set(Ellipsis)
 
 
 # Context manager or decorator to set and unset the context vars


### PR DESCRIPTION
resolves #82

### Description

This is part of the fix for #dbt-core/8866, a problem with node_info persisting when it shouldn't.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-common/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-common/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
 
