### PR TITLE
Stream instead of buffer JSON in read_json/write_json

### DIFF
--- a/.changes/unreleased/Under the Hood-20240314-161737.yaml
+++ b/.changes/unreleased/Under the Hood-20240314-161737.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Stream JSON on read/write instead of holding it in memory
+time: 2024-03-14T16:17:37.570328-04:00
+custom:
+  Author: peterallenwebb
+  Issue: "96"

--- a/dbt_common/clients/system.py
+++ b/dbt_common/clients/system.py
@@ -293,7 +293,7 @@ def write_file(path: str, contents: str = "") -> bool:
 
 def read_json(path: str) -> Dict[str, Any]:
     path = convert_path(path)
-    with open(path, "rb") as f:
+    with open(path, "r") as f:
         return json.load(f)
 
 

--- a/dbt_common/utils/executor.py
+++ b/dbt_common/utils/executor.py
@@ -74,6 +74,6 @@ def executor(config: HasThreadingConfig) -> ConnectingExecutor:
     else:
         return MultiThreadedExecutor(
             max_workers=config.threads,
-            initializer=_thread_initializer,
-            initargs=(get_invocation_context(),),
+            initializer=_thread_initializer,  # type: ignore
+            initargs=(get_invocation_context(),),  # type: ignore
         )


### PR DESCRIPTION
resolves https://dbtlabs.atlassian.net/browse/MNTL-179

### Description

There is no reason to keep JSON in memory as an intermediate step during read/write, and it was contributing to max resident set size, so stream it instead.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-common/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-common/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
 
