### PR TITLE
Improve startup performance by lazy-compiling mashumaro serialization…

### DIFF
--- a/.changes/unreleased/Under the Hood-20240319-122548.yaml
+++ b/.changes/unreleased/Under the Hood-20240319-122548.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Improve startup performance by lazy-compiling mashumaro serialization functions
+time: 2024-03-19T12:25:48.615365-04:00
+custom:
+  Author: peterallenwebb
+  Issue: "97"

--- a/dbt_common/dataclass_schema.py
+++ b/dbt_common/dataclass_schema.py
@@ -42,6 +42,7 @@ class dbtMashConfig(MashBaseConfig):
         "additionalProperties": False,
     }
     serialize_by_alias = True
+    lazy_compilation = True
 
 
 # This class pulls in DataClassDictMixin from Mashumaro. The 'to_dict'


### PR DESCRIPTION
resolves #97 

### Description

Mashumaro compilation consumed considerable startup time, by configuring it for lazy-compilation instead we get that time back.

**Before:**
```
dbt --help.   1.5s
dbt --version 1.7s
```

**After:**
```
dbt --help    0.7s
dbt --version 0.9s
```

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-common/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-common/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
 
