### PR TITLE
Add "Private" Environment Variables

### DIFF
--- a/.changes/unreleased/Features-20240410-090810.yaml
+++ b/.changes/unreleased/Features-20240410-090810.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Support environment variables which dbt can see but user code cannot.
+time: 2024-04-10T09:08:10.068999-04:00
+custom:
+  Author: peterallenwebb
+  Issue: "103"

--- a/dbt_common/constants.py
+++ b/dbt_common/constants.py
@@ -1,1 +1,6 @@
+# Prefix which identifies environment variables which contains secrets.
 SECRET_ENV_PREFIX = "DBT_ENV_SECRET_"
+
+# Prefix which identifies environment variables that should not be visible
+# via macros, flags, or other user-facing mechanisms.
+PRIVATE_ENV_PREFIX = "DBT_ENV_PRIVATE_"

--- a/dbt_common/context.py
+++ b/dbt_common/context.py
@@ -8,11 +8,7 @@ class InvocationContext:
     def __init__(self, env: Mapping[str, str]):
         self._env = {k: v for k, v in env.items() if not k.startswith(PRIVATE_ENV_PREFIX)}
         self._env_secrets: Optional[List[str]] = None
-        self._env_private = {
-            k[len(PRIVATE_ENV_PREFIX) :]: v
-            for k, v in env.items()
-            if k.startswith(PRIVATE_ENV_PREFIX)
-        }
+        self._env_private = {k: v for k, v in env.items() if k.startswith(PRIVATE_ENV_PREFIX)}
         self.recorder = None
         # This class will also eventually manage the invocation_id, flags, event manager, etc.
 

--- a/dbt_common/context.py
+++ b/dbt_common/context.py
@@ -1,19 +1,28 @@
 from contextvars import ContextVar, copy_context
 from typing import List, Mapping, Optional
 
-from dbt_common.constants import SECRET_ENV_PREFIX
+from dbt_common.constants import PRIVATE_ENV_PREFIX, SECRET_ENV_PREFIX
 
 
 class InvocationContext:
     def __init__(self, env: Mapping[str, str]):
-        self._env = env
+        self._env = {k: v for k, v in env.items() if not k.startswith(PRIVATE_ENV_PREFIX)}
         self._env_secrets: Optional[List[str]] = None
+        self._env_private = {
+            k[len(PRIVATE_ENV_PREFIX) :]: v
+            for k, v in env.items()
+            if k.startswith(PRIVATE_ENV_PREFIX)
+        }
         self.recorder = None
         # This class will also eventually manage the invocation_id, flags, event manager, etc.
 
     @property
     def env(self) -> Mapping[str, str]:
         return self._env
+
+    @property
+    def env_private(self) -> Mapping[str, str]:
+        return self._env_private
 
     @property
     def env_secrets(self) -> List[str]:

--- a/tests/unit/test_invocation_context.py
+++ b/tests/unit/test_invocation_context.py
@@ -1,4 +1,4 @@
-from dbt_common.constants import SECRET_ENV_PREFIX
+from dbt_common.constants import PRIVATE_ENV_PREFIX, SECRET_ENV_PREFIX
 from dbt_common.context import InvocationContext
 
 
@@ -17,3 +17,17 @@ def test_invocation_context_secrets():
     }
     ic = InvocationContext(env=test_env)
     assert set(ic.env_secrets) == set(["secret1", "secret2"])
+
+
+def test_invocation_context_private():
+    test_env = {
+        f"{PRIVATE_ENV_PREFIX}_VAR_1": "private1",
+        f"{PRIVATE_ENV_PREFIX}VAR_2": "private2",
+        f"{PRIVATE_ENV_PREFIX}": "private3",
+        "NON_PRIVATE": "non-private-1",
+        f"foo{PRIVATE_ENV_PREFIX}": "non-private-2",
+    }
+    ic = InvocationContext(env=test_env)
+    assert ic.env_secrets == []
+    assert ic.env_private == {"_VAR_1": "private1", "VAR_2": "private2", "": "private3"}
+    assert ic.env == {"NON_PRIVATE": "non-private-1", f"foo{PRIVATE_ENV_PREFIX}": "non-private-2"}

--- a/tests/unit/test_invocation_context.py
+++ b/tests/unit/test_invocation_context.py
@@ -29,5 +29,9 @@ def test_invocation_context_private():
     }
     ic = InvocationContext(env=test_env)
     assert ic.env_secrets == []
-    assert ic.env_private == {"_VAR_1": "private1", "VAR_2": "private2", "": "private3"}
+    assert ic.env_private == {
+        f"{PRIVATE_ENV_PREFIX}_VAR_1": "private1",
+        f"{PRIVATE_ENV_PREFIX}VAR_2": "private2",
+        f"{PRIVATE_ENV_PREFIX}": "private3",
+    }
     assert ic.env == {"NON_PRIVATE": "non-private-1", f"foo{PRIVATE_ENV_PREFIX}": "non-private-2"}


### PR DESCRIPTION
### Description

Support environment variables with a DBT_ENV_PRIVATE_ prefix, which dbt can see, but user code cannot.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-common/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-common/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
 
