### PR TITLE
Add `error_tag` util to the `ui` module

### DIFF
--- a/.changes/unreleased/Features-20240412-105245.yaml
+++ b/.changes/unreleased/Features-20240412-105245.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Add `error_tag` util to the `ui` module
+time: 2024-04-12T10:52:45.887334-07:00
+custom:
+  Author: QMalcolm
+  Issue: "107"

--- a/dbt_common/ui.py
+++ b/dbt_common/ui.py
@@ -80,3 +80,7 @@ def line_wrap_message(msg: str, subtract: int = 0, dedent: bool = True, prefix: 
 
 def warning_tag(msg: str) -> str:
     return f'[{yellow("WARNING")}]: {msg}'
+
+
+def error_tag(msg: str) -> str:
+    return f'[{red("ERROR")}]: {msg}'

--- a/tests/unit/test_ui.py
+++ b/tests/unit/test_ui.py
@@ -1,0 +1,11 @@
+from dbt_common.ui import warning_tag, error_tag
+
+
+def test_warning_tag():
+    tagged = warning_tag("hi")
+    assert "WARNING" in tagged
+
+
+def test_error_tag():
+    tagged = error_tag("hi")
+    assert "ERROR" in tagged


### PR DESCRIPTION
resolves #107

### Description

In https://github.com/dbt-labs/dbt-core/pull/9886 we found that we needed an [error_tag function](https://github.com/dbt-labs/dbt-core/pull/9886/commits/c678cbcec5fff0951ab52a1206bd324e10f79d0c#diff-a307286f8c93d8a9dbf3a863a62a6b712921d15f6b4cf9d885b15a45be68f05a). Because it didn't exist in dbt-common, we added it to core temporarily as a stop gap. This PR gets it added to dbt-common so core can remove the stop gap.

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-common/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [X] I have run this code in development and it appears to resolve the stated issue
- [X] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [X] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-common/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
 
