### PR TITLE
Add ability to `silence` events via `WarnErrorOptions`

### DIFF
--- a/.changes/unreleased/Features-20240419-232030.yaml
+++ b/.changes/unreleased/Features-20240419-232030.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Add ability to silence warnings via `WarnErrorOptions`
+time: 2024-04-19T23:20:30.014054-07:00
+custom:
+  Author: QMalcolm
+  Issue: "111"

--- a/dbt_common/events/functions.py
+++ b/dbt_common/events/functions.py
@@ -114,12 +114,13 @@ def msg_to_dict(msg: EventMsg) -> dict:
 
 
 def warn_or_error(event, node=None) -> None:
-    if WARN_ERROR or WARN_ERROR_OPTIONS.includes(type(event).__name__):
+    event_name = type(event).__name__
+    if WARN_ERROR or WARN_ERROR_OPTIONS.includes(event_name):
         # TODO: resolve this circular import when at top
         from dbt_common.exceptions import EventCompilationError
 
         raise EventCompilationError(event.message(), node)
-    elif not WARN_ERROR_OPTIONS.silenced(type(event).__name__):
+    elif not WARN_ERROR_OPTIONS.silenced(event_name):
         fire_event(event)
 
 

--- a/dbt_common/events/functions.py
+++ b/dbt_common/events/functions.py
@@ -119,7 +119,7 @@ def warn_or_error(event, node=None) -> None:
         from dbt_common.exceptions import EventCompilationError
 
         raise EventCompilationError(event.message(), node)
-    else:
+    elif not WARN_ERROR_OPTIONS.silenced(type(event).__name__):
         fire_event(event)
 
 

--- a/dbt_common/helper_types.py
+++ b/dbt_common/helper_types.py
@@ -36,6 +36,7 @@ class IncludeExclude(dbtClassMixin):
 
     include: Union[str, List[str]]
     exclude: List[str] = field(default_factory=list)
+    silence: List[str] = field(default_factory=list)
 
     def __post_init__(self):
         if isinstance(self.include, str) and self.include not in self.INCLUDE_ALL:
@@ -54,6 +55,8 @@ class IncludeExclude(dbtClassMixin):
         if isinstance(self.exclude, list):
             self._validate_items(self.exclude)
 
+        self._validate_items(self.silence)
+
     def includes(self, item_name: str):
         return (
             item_name in self.include or self.include in self.INCLUDE_ALL
@@ -69,9 +72,10 @@ class WarnErrorOptions(IncludeExclude):
         include: Union[str, List[str]],
         exclude: Optional[List[str]] = None,
         valid_error_names: Optional[Set[str]] = None,
+        silence: Optional[List[str]] = None,
     ):
         self._valid_error_names: Set[str] = valid_error_names or set()
-        super().__init__(include=include, exclude=(exclude or []))
+        super().__init__(include=include, exclude=(exclude or []), silence=(silence or []))
 
     def _validate_items(self, items: List[str]):
         for item in items:

--- a/dbt_common/helper_types.py
+++ b/dbt_common/helper_types.py
@@ -57,10 +57,15 @@ class IncludeExclude(dbtClassMixin):
 
         self._validate_items(self.silence)
 
-    def includes(self, item_name: str):
+    def includes(self, item_name: str) -> bool:
         return (
-            item_name in self.include or self.include in self.INCLUDE_ALL
-        ) and item_name not in self.exclude
+            (item_name in self.include or self.include in self.INCLUDE_ALL)
+            and item_name not in self.exclude
+            and not self.silenced(item_name)
+        )
+
+    def silenced(self, item_name: str) -> bool:
+        return item_name in self.silence
 
     def _validate_items(self, items: List[str]):
         pass

--- a/tests/unit/test_events.py
+++ b/tests/unit/test_events.py
@@ -20,7 +20,14 @@ from dbt_common.events.functions import msg_to_dict, msg_to_json
 def get_all_subclasses(cls):
     all_subclasses = []
     for subclass in cls.__subclasses__():
-        if subclass not in [TestLevel, DebugLevel, WarnLevel, InfoLevel, ErrorLevel, DynamicLevel]:
+        if subclass not in [
+            TestLevel,
+            DebugLevel,
+            WarnLevel,
+            InfoLevel,
+            ErrorLevel,
+            DynamicLevel,
+        ] and not subclass.__module__.startswith("test_"):
             all_subclasses.append(subclass)
         all_subclasses.extend(get_all_subclasses(subclass))
     return set(all_subclasses)

--- a/tests/unit/test_functions.py
+++ b/tests/unit/test_functions.py
@@ -1,0 +1,79 @@
+import pytest
+
+from dataclasses import dataclass, field
+from dbt_common.events import functions
+from dbt_common.events.base_types import EventLevel, EventMsg, WarnLevel
+from dbt_common.events.event_manager import EventManager
+from dbt_common.events.event_manager_client import ctx_set_event_manager
+from dbt_common.exceptions import EventCompilationError
+from dbt_common.helper_types import WarnErrorOptions
+from typing import List, Set
+
+
+# Re-implementing `Note` event as a warn event for
+# our testing purposes
+class Note(WarnLevel):
+    def code(self) -> str:
+        return "Z050"
+
+    def message(self) -> str:
+        return self.msg
+
+
+@dataclass
+class EventCatcher:
+    caught_events: List[EventMsg] = field(default_factory=list)
+
+    def catch(self, event: EventMsg) -> None:
+        self.caught_events.append(event)
+
+
+@pytest.fixture(scope="function")
+def event_catcher() -> EventCatcher:
+    return EventCatcher()
+
+
+@pytest.fixture(scope="function")
+def set_event_manager_with_catcher(event_catcher: EventCatcher) -> None:
+    event_manager = EventManager()
+    event_manager.callbacks.append(event_catcher.catch)
+    ctx_set_event_manager(event_manager)
+
+
+@pytest.fixture(scope="function")
+def valid_error_names() -> Set[str]:
+    return {Note.__name__}
+
+
+class TestWarnOrError:
+    def test_fires_error(self, valid_error_names: Set[str]):
+        functions.WARN_ERROR_OPTIONS = WarnErrorOptions(
+            include="*", valid_error_names=valid_error_names
+        )
+        with pytest.raises(EventCompilationError):
+            functions.warn_or_error(Note(msg="hi"))
+
+    def test_fires_warning(
+        self,
+        valid_error_names: Set[str],
+        event_catcher: EventCatcher,
+        set_event_manager_with_catcher,
+    ):
+        functions.WARN_ERROR_OPTIONS = WarnErrorOptions(
+            include="*", exclude=list(valid_error_names), valid_error_names=valid_error_names
+        )
+        functions.warn_or_error(Note(msg="hi"))
+        assert len(event_catcher.caught_events) == 1
+        assert event_catcher.caught_events[0].info.level == EventLevel.WARN.value
+
+    def test_silenced(
+        self,
+        valid_error_names: Set[str],
+        event_catcher: EventCatcher,
+        set_event_manager_with_catcher,
+    ):
+        functions.WARN_ERROR_OPTIONS = WarnErrorOptions(
+            include="*", silence=list(valid_error_names), valid_error_names=valid_error_names
+        )
+        functions.warn_or_error(Note(msg="hi"))
+        assert len(event_catcher.caught_events) == 0

--- a/tests/unit/test_helper_types.py
+++ b/tests/unit/test_helper_types.py
@@ -57,3 +57,18 @@ class TestWarnErrorOptions:
         )
         assert warn_error_options.include == "*"
         assert warn_error_options.exclude == ["ValidError"]
+
+    def test_init_default_silence(self):
+        my_options = WarnErrorOptions(include="*")
+        assert my_options.silence == []
+
+    def test_init_invalid_silence_event(self):
+        with pytest.raises(ValidationError):
+            WarnErrorOptions(include="*", silence=["InvalidError"])
+
+    def test_init_valid_silence_event(self):
+        all_events = ["MySilencedEvent"]
+        my_options = WarnErrorOptions(
+            include="*", silence=all_events, valid_error_names=all_events
+        )
+        assert my_options.silence == all_events

--- a/tests/unit/test_helper_types.py
+++ b/tests/unit/test_helper_types.py
@@ -13,19 +13,27 @@ class TestIncludeExclude:
             IncludeExclude(include=["ItemA"], exclude=["ItemB"])
 
     @pytest.mark.parametrize(
-        "include,exclude,expected_includes",
+        "include,exclude,silence,expected_includes",
         [
-            ("all", [], True),
-            ("*", [], True),
-            ("*", ["ItemA"], False),
-            (["ItemA"], [], True),
-            (["ItemA", "ItemB"], [], True),
+            ("all", [], [], True),
+            ("*", [], [], True),
+            ("*", ["ItemA"], [], False),
+            (["ItemA"], [], [], True),
+            (["ItemA", "ItemB"], [], [], True),
+            (["ItemA"], [], ["ItemA"], False),
+            ("*", [], ["ItemA"], False),
+            ("*", [], ["ItemB"], True),
         ],
     )
-    def test_includes(self, include, exclude, expected_includes):
-        include_exclude = IncludeExclude(include=include, exclude=exclude)
+    def test_includes(self, include, exclude, silence, expected_includes):
+        include_exclude = IncludeExclude(include=include, exclude=exclude, silence=silence)
 
         assert include_exclude.includes("ItemA") == expected_includes
+
+    def test_silenced(self):
+        my_options = IncludeExclude(include="*", silence=["ItemA"])
+        assert my_options.silenced("ItemA")
+        assert not my_options.silenced("ItemB")
 
 
 class TestWarnErrorOptions:

--- a/tests/unit/test_helper_types.py
+++ b/tests/unit/test_helper_types.py
@@ -13,27 +13,19 @@ class TestIncludeExclude:
             IncludeExclude(include=["ItemA"], exclude=["ItemB"])
 
     @pytest.mark.parametrize(
-        "include,exclude,silence,expected_includes",
+        "include,exclude,expected_includes",
         [
-            ("all", [], [], True),
-            ("*", [], [], True),
-            ("*", ["ItemA"], [], False),
-            (["ItemA"], [], [], True),
-            (["ItemA", "ItemB"], [], [], True),
-            (["ItemA"], [], ["ItemA"], False),
-            ("*", [], ["ItemA"], False),
-            ("*", [], ["ItemB"], True),
+            ("all", [], True),
+            ("*", [], True),
+            ("*", ["ItemA"], False),
+            (["ItemA"], [], True),
+            (["ItemA", "ItemB"], [], True),
         ],
     )
-    def test_includes(self, include, exclude, silence, expected_includes):
-        include_exclude = IncludeExclude(include=include, exclude=exclude, silence=silence)
+    def test_includes(self, include, exclude, expected_includes):
+        include_exclude = IncludeExclude(include=include, exclude=exclude)
 
         assert include_exclude.includes("ItemA") == expected_includes
-
-    def test_silenced(self):
-        my_options = IncludeExclude(include="*", silence=["ItemA"])
-        assert my_options.silenced("ItemA")
-        assert not my_options.silenced("ItemB")
 
 
 class TestWarnErrorOptions:
@@ -80,3 +72,23 @@ class TestWarnErrorOptions:
             include="*", silence=all_events, valid_error_names=all_events
         )
         assert my_options.silence == all_events
+
+    @pytest.mark.parametrize(
+        "include,silence,expected_includes",
+        [
+            (["ItemA"], ["ItemA"], False),
+            ("*", ["ItemA"], False),
+            ("*", ["ItemB"], True),
+        ],
+    )
+    def test_includes(self, include, silence, expected_includes):
+        include_exclude = WarnErrorOptions(
+            include=include, silence=silence, valid_error_names={"ItemA", "ItemB"}
+        )
+
+        assert include_exclude.includes("ItemA") == expected_includes
+
+    def test_silenced(self):
+        my_options = WarnErrorOptions(include="*", silence=["ItemA"], valid_error_names={"ItemA"})
+        assert my_options.silenced("ItemA")
+        assert not my_options.silenced("ItemB")


### PR DESCRIPTION
resolves #111

### Description

We want to be able to silence events via `warn_or_error`. This enables that.

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-common/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [X] I have run this code in development and it appears to resolve the stated issue
- [X] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [X] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-common/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
 
