### PR TITLE
[tidy first] move exception import to top of functions.py

### DIFF
--- a/dbt_common/events/functions.py
+++ b/dbt_common/events/functions.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 from dbt_common.events.event_manager_client import get_event_manager
+from dbt_common.exceptions import EventCompilationError
 from dbt_common.invocation import get_invocation_id
 from dbt_common.helper_types import WarnErrorOptions
 from dbt_common.utils.encoding import ForgivingJSONEncoder
@@ -115,9 +116,6 @@ def msg_to_dict(msg: EventMsg) -> dict:
 
 def warn_or_error(event, node=None) -> None:
     if WARN_ERROR or WARN_ERROR_OPTIONS.includes(type(event).__name__):
-        # TODO: resolve this circular import when at top
-        from dbt_common.exceptions import EventCompilationError
-
         raise EventCompilationError(event.message(), node)
     else:
         fire_event(event)


### PR DESCRIPTION
resolves #N/A

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->

### Description

<!---
  Describe the Pull Request here. Add any references and info to help reviewers
  understand your changes. Include any tradeoffs you considered.
-->

The necessity to import this exception dynamically was caused by circular dependencies which have been untangled as part of https://github.com/dbt-labs/dbt-core/issues/8917. This should no longer cause a circular dependency!

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-common/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-common/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
 
