### PR TITLE
move agate pin back to 1.7

### DIFF
--- a/.changes/unreleased/Dependencies-20240425-112704.yaml
+++ b/.changes/unreleased/Dependencies-20240425-112704.yaml
@@ -1,5 +1,5 @@
 kind: Dependencies
-body: Pin agate `>=1.8.0,<1.10`
+body: Pin agate `>=1.7.0,<1.10`
 time: 2024-04-25T11:27:04.91767-05:00
 custom:
   Author: emmyoop

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
-  "agate>=1.8.0,<1.10",
+  "agate>=1.7.0,<1.10",
   "colorama>=0.3.9,<0.5",
   "isodate>=0.6,<0.7",
   "jsonschema>=4.0,<5.0",


### PR DESCRIPTION

### Description

Moving the lower pin is causing test failures in dbt-core that block releasing dbt-common that causes dbt-core tests to fail...

Moving the lower pin to resolve the conflicts.

backs out bumping lower pin in #119 

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-common/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-common/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
 
