### PR TITLE
[TIDY FIRST] Remove conditional `typing_extensions` import for python < 3.8

### DIFF
--- a/dbt_common/events/base_types.py
+++ b/dbt_common/events/base_types.py
@@ -10,10 +10,7 @@ from typing import Callable, Optional
 
 from dbt_common.invocation import get_invocation_id
 
-if sys.version_info >= (3, 8):
-    from typing import Protocol
-else:
-    from typing_extensions import Protocol
+from typing import Protocol
 
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #


### PR DESCRIPTION
This repository doesn't currently, and never has, supported python versions less than 3.8. The conditional import being removed here is a holdover from when this code was cut out of dbt-core (which no longer supports python less than 3.8 either).

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-common/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [X] I have run this code in development and it appears to resolve the stated issue
- [ ] ~I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR~
- [ ] ~I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-common/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)~
 
