### PR TITLE
rename var

### DIFF
--- a/dbt_common/record.py
+++ b/dbt_common/record.py
@@ -166,9 +166,6 @@ def get_record_mode_from_env() -> Optional[RecorderMode]:
     if record_mode.lower() == "record":
         return RecorderMode.RECORD
     # replaying requires a file path, otherwise treat as noop
-    elif record_mode.lower() == "diff" and os.environ.get("DBT_RECORDER_FILE_PATH") is not None:
-        return RecorderMode.RECORD
-    # replaying requires a file path, otherwise treat as noop
     elif record_mode.lower() == "replay" and os.environ.get("DBT_RECORDER_FILE_PATH") is not None:
         return RecorderMode.REPLAY
 

--- a/dbt_common/record.py
+++ b/dbt_common/record.py
@@ -166,9 +166,10 @@ def get_record_mode_from_env() -> Optional[RecorderMode]:
     if record_mode.lower() == "record":
         return RecorderMode.RECORD
     # replaying requires a file path, otherwise treat as noop
-    elif (
-        record_mode.lower() == "replay" and os.environ.get("DBT_RECORDER_REPLAY_PATH") is not None
-    ):
+    elif record_mode.lower() == "diff" and os.environ.get("DBT_RECORDER_FILE_PATH") is not None:
+        return RecorderMode.RECORD
+    # replaying requires a file path, otherwise treat as noop
+    elif record_mode.lower() == "replay" and os.environ.get("DBT_RECORDER_FILE_PATH") is not None:
         return RecorderMode.REPLAY
 
     # if you don't specify record/replay it's a noop

--- a/docs/guides/record_replay.md
+++ b/docs/guides/record_replay.md
@@ -42,7 +42,7 @@ DBT_RECORDER_MODE=record DBT_RECODER_TYPES=QueryRecord,GetEnvRecord dbt run
 
 replay need the file to replay
 ```bash
-DBT_RECORDER_MODE=replay DBT_RECORDER_REPLAY_PATH=recording.json dbt run
+DBT_RECORDER_MODE=replay DBT_RECORDER_FILE_PATH=recording.json dbt run
 ```
 
 ## Final Thoughts

--- a/tests/unit/test_record.py
+++ b/tests/unit/test_record.py
@@ -48,11 +48,11 @@ def setup():
     # capture the previous state of the environment variables
     prev_mode = os.environ.get("DBT_RECORDER_MODE", None)
     prev_type = os.environ.get("DBT_RECORDER_TYPES", None)
-    prev_fp = os.environ.get("DBT_RECORDER_REPLAY_PATH", None)
+    prev_fp = os.environ.get("DBT_RECORDER_FILE_PATH", None)
     # clear the environment variables
     os.environ.pop("DBT_RECORDER_MODE", None)
     os.environ.pop("DBT_RECORDER_TYPES", None)
-    os.environ.pop("DBT_RECORDER_REPLAY_PATH", None)
+    os.environ.pop("DBT_RECORDER_FILE_PATH", None)
     yield
     # reset the environment variables to their previous state
     if prev_mode is None:
@@ -64,9 +64,9 @@ def setup():
     else:
         os.environ["DBT_RECORDER_TYPES"] = prev_type
     if prev_fp is None:
-        os.environ.pop("DBT_RECORDER_REPLAY_PATH", None)
+        os.environ.pop("DBT_RECORDER_FILE_PATH", None)
     else:
-        os.environ["DBT_RECORDER_REPLAY_PATH"] = prev_fp
+        os.environ["DBT_RECORDER_FILE_PATH"] = prev_fp
 
 
 def test_decorator_records(setup):
@@ -118,7 +118,7 @@ def test_record_types(setup):
 
 def test_decorator_replays(setup):
     os.environ["DBT_RECORDER_MODE"] = "Replay"
-    os.environ["DBT_RECORDER_REPLAY_PATH"] = "record.json"
+    os.environ["DBT_RECORDER_FILE_PATH"] = "record.json"
     recorder = Recorder(RecorderMode.REPLAY, None)
     set_invocation_context({})
     get_invocation_context().recorder = recorder


### PR DESCRIPTION
resolves None

### Description

Rename env var to be more generic so it can be reused for diffing.

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-common/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-common/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
 
