### PR TITLE
Move CatalogKey, ColumnMetadata, ColumnMap, CatalogTable to dbt-common

### DIFF
--- a/.changes/unreleased/Under the Hood-20240603-123631.yaml
+++ b/.changes/unreleased/Under the Hood-20240603-123631.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Move CatalogKey, ColumnMetadata, ColumnMap, CatalogTable to dbt-common
+time: 2024-06-03T12:36:31.542118+02:00
+custom:
+    Author: aranke
+    Issue: "147"

--- a/dbt_common/contracts/metadata.py
+++ b/dbt_common/contracts/metadata.py
@@ -1,7 +1,8 @@
 from dataclasses import dataclass
-from typing import Dict, Optional, Union
+from typing import Dict, Optional, Union, NamedTuple
 
 from dbt_common.dataclass_schema import dbtClassMixin
+from dbt_common.utils.formatting import lowercase
 
 
 @dataclass
@@ -24,3 +25,35 @@ class TableMetadata(dbtClassMixin):
     database: Optional[str] = None
     comment: Optional[str] = None
     owner: Optional[str] = None
+
+
+CatalogKey = NamedTuple(
+    "CatalogKey", [("database", Optional[str]), ("schema", str), ("name", str)]
+)
+
+
+@dataclass
+class ColumnMetadata(dbtClassMixin):
+    type: str
+    index: int
+    name: str
+    comment: Optional[str] = None
+
+
+ColumnMap = Dict[str, ColumnMetadata]
+
+
+@dataclass
+class CatalogTable(dbtClassMixin):
+    metadata: TableMetadata
+    columns: ColumnMap
+    stats: StatsDict
+    # the same table with two unique IDs will just be listed two times
+    unique_id: Optional[str] = None
+
+    def key(self) -> CatalogKey:
+        return CatalogKey(
+            lowercase(self.metadata.database),
+            self.metadata.schema.lower(),
+            self.metadata.name.lower(),
+        )


### PR DESCRIPTION
### Description

As per [internal Slack conversation](https://dbt-labs.slack.com/archives/C05D73VFE3H/p1717410556102569?thread_ts=1716913807.618009&cid=C05D73VFE3H), we want to move the catalog artifact schema to `dbt-common` so adapters can depend on them ([PR 1](https://github.com/dbt-labs/dbt-adapters/pull/231), [PR 2](https://github.com/dbt-labs/dbt-snowflake/pull/1064)).

This PR moves the following to `dbt-common`: `CatalogKey`, `ColumnMetadata`, `ColumnMap`, `CatalogTable`
Draft PR in `dbt-core` that keeps imports intact but uses code from `dbt-common` is here: https://github.com/dbt-labs/dbt-core/pull/10253

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-common/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-common/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
 
