### PR TITLE
Support DIFF as a new mode for recording

### DIFF
--- a/.changes/unreleased/Under the Hood-20240617-204541.yaml
+++ b/.changes/unreleased/Under the Hood-20240617-204541.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Add support for basic diff of run recordings.
+time: 2024-06-17T20:45:41.123374-05:00
+custom:
+  Author: emmyoop
+  Issue: "144"

--- a/dbt_common/clients/system.py
+++ b/dbt_common/clients/system.py
@@ -708,20 +708,3 @@ class GetEnvRecord(Record):
 @record_function(GetEnvRecord)
 def get_env() -> Dict[str, str]:
     return dict(os.environ)
-
-
-# @dataclasses.dataclass
-# class GetProjectParams:
-#     root_path: str
-#     ?
-
-
-# @dataclasses.dataclass
-# class GetProjectResult:
-#     pass
-
-
-# @Recorder.register_record_type
-# class GetProjectRecord(Record):
-#     params_cls = GetProjectParams
-#     result_cls = GetProjectResult

--- a/dbt_common/clients/system.py
+++ b/dbt_common/clients/system.py
@@ -708,3 +708,20 @@ class GetEnvRecord(Record):
 @record_function(GetEnvRecord)
 def get_env() -> Dict[str, str]:
     return dict(os.environ)
+
+
+# @dataclasses.dataclass
+# class GetProjectParams:
+#     root_path: str
+#     ?
+
+
+# @dataclasses.dataclass
+# class GetProjectResult:
+#     pass
+
+
+# @Recorder.register_record_type
+# class GetProjectRecord(Record):
+#     params_cls = GetProjectParams
+#     result_cls = GetProjectResult

--- a/dbt_common/record.py
+++ b/dbt_common/record.py
@@ -59,7 +59,7 @@ class Diff:
 class RecorderMode(Enum):
     RECORD = 1
     REPLAY = 2
-    RECORD_QUERIES = 3
+    DIFF = 3
 
 
 class Recorder:
@@ -155,7 +155,7 @@ def get_record_mode_from_env() -> Optional[RecorderMode]:
     """
     Get the record mode from the environment variables.
 
-    If the mode is not set to 'RECORD' or 'REPLAY', return None.
+    If the mode is not set to 'RECORD', 'DIFF' or 'REPLAY', return None.
     Expected format: 'DBT_RECORDER_MODE=RECORD'
     """
     record_mode = os.environ.get("DBT_RECORDER_MODE")
@@ -165,6 +165,9 @@ def get_record_mode_from_env() -> Optional[RecorderMode]:
 
     if record_mode.lower() == "record":
         return RecorderMode.RECORD
+    # diffing requires a file path, otherwise treat as noop
+    elif record_mode.lower() == "diff" and os.environ.get("DBT_RECORDER_FILE_PATH") is not None:
+        return RecorderMode.DIFF
     # replaying requires a file path, otherwise treat as noop
     elif record_mode.lower() == "replay" and os.environ.get("DBT_RECORDER_FILE_PATH") is not None:
         return RecorderMode.REPLAY

--- a/dbt_common/record.py
+++ b/dbt_common/record.py
@@ -63,6 +63,7 @@ class Diff:
 
     def diff_query_records(self, current: List, previous: List) -> Dict[str, Any]:
         # some of the table results are returned as a stringified list of dicts that don't diff because order isn't consistent
+        # convert it into a list of dicts so it can be diffed, ignoring order
         for i in range(len(current)):
             if current[i].get("result").get("table") is not None:
                 current[i] = json.loads(current[i]["result"]["table"])
@@ -89,7 +90,7 @@ class Diff:
         return DeepDiff(current, previous, ignore_order=True, verbose_level=2)
 
     def calculate_diff(self) -> Dict[str, Any]:
-        # TODO: should i convert the files to Records and diff the records?
+        # TODO: should i convert the files to Records and diff the records? blocked on this for now by MNTL-308
 
         with open(self.current_recording_path) as current_recording:
             current_dct = json.load(current_recording)

--- a/dbt_common/record.py
+++ b/dbt_common/record.py
@@ -62,13 +62,15 @@ class Diff:
         self.previous_recording_path = previous_recording_path
 
     def diff_query_records(self, current: List, previous: List) -> Dict[str, Any]:
-        # some of the table results are returned as a stringified list of dicts that don't diff because order isn't consistent
-        # convert it into a list of dicts so it can be diffed, ignoring order
+        # some of the table results are returned as a stringified list of dicts that don't
+        # diff because order isn't consistent convert it into a list of dicts so it can
+        # be diffed ignoring order
+
         for i in range(len(current)):
             if current[i].get("result").get("table") is not None:
-                current[i] = json.loads(current[i]["result"]["table"])
+                current[i]["result"]["table"] = json.loads(current[i]["result"]["table"])
             if previous[i].get("result").get("table") is not None:
-                previous[i] = json.loads(previous[i]["result"]["table"])
+                previous[i]["result"]["table"] = json.loads(previous[i]["result"]["table"])
 
         return DeepDiff(current, previous, ignore_order=True, verbose_level=2)
 
@@ -90,7 +92,7 @@ class Diff:
         return DeepDiff(current, previous, ignore_order=True, verbose_level=2)
 
     def calculate_diff(self) -> Dict[str, Any]:
-        # TODO: should i convert the files to Records and diff the records? blocked on this for now by MNTL-308
+        # TODO: should i convert the files to Records and diff the records? - blocked on this for now by MNTL-308
 
         with open(self.current_recording_path) as current_recording:
             current_dct = json.load(current_recording)

--- a/dbt_common/record.py
+++ b/dbt_common/record.py
@@ -205,6 +205,8 @@ class Recorder:
         self.diff: Diff
         self.previous_recording_path = previous_recording_path
         self.current_recording_path = current_recording_path
+        self.dir_path = os.path.join(os.path.dirname(self.current_recording_path), "recordings")
+        os.makedirs(self.dir_path, exist_ok=True)  # Create the directory if it does not exist
 
         # TODO: better way to do this?
         if self.previous_recording_path is not None and self.mode == RecorderMode.REPLAY:
@@ -245,7 +247,8 @@ class Recorder:
         return match
 
     def write(self) -> None:
-        with open(self.current_recording_path, "w") as file:
+        fp = os.path.join(self.dir_path, os.path.basename(self.current_recording_path))
+        with open(fp, "w") as file:
             json.dump(self._to_dict(), file)
 
     def _to_dict(self) -> Dict:
@@ -285,9 +288,10 @@ class Recorder:
         return result_tuple[0] if len(result_tuple) == 1 else result_tuple
 
     def write_diffs(self, diff_file_name) -> None:
+        fp = os.path.join(self.dir_path, os.path.basename(diff_file_name))
         json.dump(
             self.diff.calculate_diff(),
-            open(diff_file_name, "w"),
+            open(fp, "w"),
         )
 
     def print_diffs(self) -> None:

--- a/dbt_common/record.py
+++ b/dbt_common/record.py
@@ -83,35 +83,6 @@ class Diff:
             previous, current, ignore_order=True, verbose_level=2, exclude_paths=exclude_paths
         )
 
-    def diff_ignore_non_root(self, current: List, previous: List) -> Dict[str, Any]:
-        # TODO: do we want to exclude non-root from the diff to avoid diffing the
-        # contents of macros that were modified externally?  If so we'll need some
-        # metadata like the project name to know what to exclude.
-        # we need the non-root values for replay so we can't always exclude them
-
-        # TODO: stop hardcoding this
-        project_name = "jaffle-shop-private"
-
-        skip_current: List = []
-        for i in range(len(current)):
-            if project_name not in current[i].get("params").get("root_path"):
-                skip_current.append(i)
-
-        skip_previous: List = []
-        for i in range(len(previous)):
-            if project_name not in previous[i].get("params").get("root_path"):
-                skip_previous.append(i)
-
-        current = [current[i] for i in range(len(current)) if i not in skip_current]
-        previous = [previous[i] for i in range(len(previous)) if i not in skip_previous]
-
-        return DeepDiff(
-            previous,
-            current,
-            ignore_order=True,
-            verbose_level=2,
-        )
-
     def diff_default(self, current: List, previous: List) -> Dict[str, Any]:
         return DeepDiff(previous, current, ignore_order=True, verbose_level=2)
 
@@ -130,10 +101,6 @@ class Diff:
                 )
             elif record_type == "GetEnvRecord":
                 diff[record_type] = self.diff_env_records(
-                    current_dct[record_type], previous_dct[record_type]
-                )
-            elif record_type in ["FindMatchingRecord", "LoadFileRecord"]:
-                diff[record_type] = self.diff_ignore_non_root(
                     current_dct[record_type], previous_dct[record_type]
                 )
             else:

--- a/dbt_common/record.py
+++ b/dbt_common/record.py
@@ -72,7 +72,7 @@ class Diff:
             if previous[i].get("result").get("table") is not None:
                 previous[i]["result"]["table"] = json.loads(previous[i]["result"]["table"])
 
-        return DeepDiff(current, previous, ignore_order=True, verbose_level=2)
+        return DeepDiff(previous, current, ignore_order=True, verbose_level=2)
 
     def diff_load_file_records(self, current: List, previous: List) -> Dict[str, Any]:
         # TODO: do we want to exclude non-root from the diff to avoid diffing the
@@ -97,8 +97,8 @@ class Diff:
         previous = [previous[i] for i in range(len(previous)) if i not in skip_previous]
 
         return DeepDiff(
-            current,
             previous,
+            current,
             ignore_order=True,
             verbose_level=2,
         )
@@ -112,7 +112,7 @@ class Diff:
         ]
 
         return DeepDiff(
-            current, previous, ignore_order=True, verbose_level=2, exclude_paths=exclude_paths
+            previous, current, ignore_order=True, verbose_level=2, exclude_paths=exclude_paths
         )
 
     def diff_find_matching_records(self, current: List, previous: List) -> Dict[str, Any]:
@@ -137,14 +137,14 @@ class Diff:
         previous = [previous[i] for i in range(len(previous)) if i not in skip_previous]
 
         return DeepDiff(
-            current,
             previous,
+            current,
             ignore_order=True,
             verbose_level=2,
         )
 
     def diff_default(self, current: List, previous: List) -> Dict[str, Any]:
-        return DeepDiff(current, previous, ignore_order=True, verbose_level=2)
+        return DeepDiff(previous, current, ignore_order=True, verbose_level=2)
 
     def calculate_diff(self) -> Dict[str, Any]:
         # TODO: should i convert the files to Records and diff the records? - blocked on this for now by MNTL-308

--- a/dbt_common/record.py
+++ b/dbt_common/record.py
@@ -205,8 +205,6 @@ class Recorder:
         self.diff: Diff
         self.previous_recording_path = previous_recording_path
         self.current_recording_path = current_recording_path
-        self.dir_path = os.path.join(os.path.dirname(self.current_recording_path), "recordings")
-        os.makedirs(self.dir_path, exist_ok=True)  # Create the directory if it does not exist
 
         # TODO: better way to do this?
         if self.previous_recording_path is not None and self.mode == RecorderMode.REPLAY:
@@ -247,8 +245,7 @@ class Recorder:
         return match
 
     def write(self) -> None:
-        fp = os.path.join(self.dir_path, os.path.basename(self.current_recording_path))
-        with open(fp, "w") as file:
+        with open(self.current_recording_path, "w") as file:
             json.dump(self._to_dict(), file)
 
     def _to_dict(self) -> Dict:
@@ -288,10 +285,9 @@ class Recorder:
         return result_tuple[0] if len(result_tuple) == 1 else result_tuple
 
     def write_diffs(self, diff_file_name) -> None:
-        fp = os.path.join(self.dir_path, os.path.basename(diff_file_name))
         json.dump(
             self.diff.calculate_diff(),
-            open(fp, "w"),
+            open(diff_file_name, "w"),
         )
 
     def print_diffs(self) -> None:

--- a/dbt_common/record.py
+++ b/dbt_common/record.py
@@ -53,8 +53,6 @@ class Record:
 
 
 class Diff:
-    """Marker class for diffs?"""
-
     def __init__(self, current_recording_path: str, previous_recording_path: str) -> None:
         self.current_recording_path = current_recording_path
         self.previous_recording_path = previous_recording_path

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ classifiers = [
 dependencies = [
   "agate>=1.7.0,<1.10",
   "colorama>=0.3.9,<0.5",
+  "deepdiff>=7.0,<8.0",
   "isodate>=0.6,<0.7",
   "jsonschema>=4.0,<5.0",
   "Jinja2>=3.1.3,<4",

--- a/tests/unit/test_diff.py
+++ b/tests/unit/test_diff.py
@@ -1,0 +1,305 @@
+import json
+import pytest
+from dbt_common.record import Diff
+
+
+@pytest.fixture
+def current_query():
+    return [
+        {
+            "params": {
+                "a": 1,
+            },
+            "result": {
+                "this": "key",
+                "table": '[{"a": 5},{"b": 7}]',
+            },
+        }
+    ]
+
+
+@pytest.fixture
+def query_modified_order():
+    return [
+        {
+            "params": {
+                "a": 1,
+            },
+            "result": {
+                "this": "key",
+                "table": '[{"b": 7},{"a": 5}]',
+            },
+        }
+    ]
+
+
+@pytest.fixture
+def query_modified_value():
+    return [
+        {
+            "params": {
+                "a": 1,
+            },
+            "result": {
+                "this": "key",
+                "table": '[{"a": 5},{"b": 10}]',
+            },
+        }
+    ]
+
+
+@pytest.fixture
+def current_simple():
+    return [
+        {
+            "params": {
+                "a": 1,
+            },
+            "result": {
+                "this": "cat",
+            },
+        }
+    ]
+
+
+@pytest.fixture
+def current_simple_modified():
+    return [
+        {
+            "params": {
+                "a": 1,
+            },
+            "result": {
+                "this": "dog",
+            },
+        }
+    ]
+
+
+@pytest.fixture
+def env_record():
+    return [
+        {
+            "params": {},
+            "result": {
+                "env": {
+                    "DBT_RECORDER_FILE_PATH": "record.json",
+                    "ANOTHER_ENV_VAR": "dogs",
+                },
+            },
+        }
+    ]
+
+
+@pytest.fixture
+def modified_env_record():
+    return [
+        {
+            "params": {},
+            "result": {
+                "env": {
+                    "DBT_RECORDER_FILE_PATH": "another_record.json",
+                    "ANOTHER_ENV_VAR": "cats",
+                },
+            },
+        }
+    ]
+
+
+def test_diff_query_records_no_diff(current_query, query_modified_order):
+    # Setup: Create an instance of Diff
+    diff_instance = Diff(
+        current_recording_path="path/to/current", previous_recording_path="path/to/previous"
+    )
+    result = diff_instance.diff_query_records(current_query, query_modified_order)
+    # the order changed but the diff should be empty
+    expected_result = {}
+    assert result == expected_result  # Replace expected_result with what you actually expect
+
+
+def test_diff_query_records_with_diff(current_query, query_modified_value):
+    diff_instance = Diff(
+        current_recording_path="path/to/current", previous_recording_path="path/to/previous"
+    )
+    result = diff_instance.diff_query_records(current_query, query_modified_value)
+    # the values changed this time
+    expected_result = {
+        "values_changed": {"root[0]['result']['table'][1]['b']": {"new_value": 7, "old_value": 10}}
+    }
+    assert result == expected_result
+
+
+def test_diff_env_records(env_record, modified_env_record):
+    diff_instance = Diff(
+        current_recording_path="path/to/current", previous_recording_path="path/to/previous"
+    )
+    result = diff_instance.diff_env_records(env_record, modified_env_record)
+    expected_result = {
+        "values_changed": {
+            "root[0]['result']['env']['ANOTHER_ENV_VAR']": {
+                "new_value": "dogs",
+                "old_value": "cats",
+            }
+        }
+    }
+    assert result == expected_result
+
+
+def test_diff_default_no_diff(current_simple):
+    diff_instance = Diff(
+        current_recording_path="path/to/current", previous_recording_path="path/to/previous"
+    )
+    # use the same list to ensure no diff
+    result = diff_instance.diff_default(current_simple, current_simple)
+    expected_result = {}
+    assert result == expected_result
+
+
+def test_diff_default_with_diff(current_simple, current_simple_modified):
+    diff_instance = Diff(
+        current_recording_path="path/to/current", previous_recording_path="path/to/previous"
+    )
+    result = diff_instance.diff_default(current_simple, current_simple_modified)
+    expected_result = {
+        "values_changed": {"root[0]['result']['this']": {"new_value": "cat", "old_value": "dog"}}
+    }
+    assert result == expected_result
+
+
+# Mock out reading the files so we don't have to
+class MockFile:
+    def __init__(self, json_data):
+        self.json_data = json_data
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        pass
+
+    def read(self):
+        return json.dumps(self.json_data)
+
+
+# Create a Mock Open Function
+def mock_open(mock_files):
+    def open_mock(file, *args, **kwargs):
+        if file in mock_files:
+            return MockFile(mock_files[file])
+        raise FileNotFoundError(f"No mock file found for {file}")
+
+    return open_mock
+
+
+def test_calculate_diff_no_diff(monkeypatch):
+    # Mock data for the files
+    current_recording_data = {
+        "GetEnvRecord": [
+            {
+                "params": {
+                    "a": 1,
+                },
+                "result": {
+                    "this": "dog",
+                },
+            }
+        ],
+        "DefaultKey": [
+            {
+                "params": {
+                    "a": 1,
+                },
+                "result": {
+                    "this": "dog",
+                },
+            }
+        ],
+    }
+    previous_recording_data = {
+        "GetEnvRecord": [
+            {
+                "params": {
+                    "a": 1,
+                },
+                "result": {
+                    "this": "dog",
+                },
+            }
+        ],
+        "DefaultKey": [
+            {
+                "params": {
+                    "a": 1,
+                },
+                "result": {
+                    "this": "dog",
+                },
+            }
+        ],
+    }
+    current_recording_path = "/path/to/current_recording.json"
+    previous_recording_path = "/path/to/previous_recording.json"
+    mock_files = {
+        current_recording_path: current_recording_data,
+        previous_recording_path: previous_recording_data,
+    }
+    monkeypatch.setattr("builtins.open", mock_open(mock_files))
+
+    # test the diff
+    diff_instance = Diff(
+        current_recording_path=current_recording_path,
+        previous_recording_path=previous_recording_path,
+    )
+    result = diff_instance.calculate_diff()
+    expected_result = {"GetEnvRecord": {}, "DefaultKey": {}}
+    assert result == expected_result
+
+
+def test_calculate_diff_with_diff(monkeypatch):
+    # Mock data for the files
+    current_recording_data = {
+        "GetEnvRecord": [
+            {
+                "params": {
+                    "a": 1,
+                },
+                "result": {
+                    "this": "dog",
+                },
+            }
+        ]
+    }
+    previous_recording_data = {
+        "GetEnvRecord": [
+            {
+                "params": {
+                    "a": 1,
+                },
+                "result": {
+                    "this": "cats",
+                },
+            }
+        ]
+    }
+    current_recording_path = "/path/to/current_recording.json"
+    previous_recording_path = "/path/to/previous_recording.json"
+    mock_files = {
+        current_recording_path: current_recording_data,
+        previous_recording_path: previous_recording_data,
+    }
+    monkeypatch.setattr("builtins.open", mock_open(mock_files))
+
+    # test the diff
+    diff_instance = Diff(
+        current_recording_path=current_recording_path,
+        previous_recording_path=previous_recording_path,
+    )
+    result = diff_instance.calculate_diff()
+    expected_result = {
+        "GetEnvRecord": {
+            "values_changed": {
+                "root[0]['result']['this']": {"new_value": "dog", "old_value": "cats"}
+            }
+        }
+    }
+    assert result == expected_result


### PR DESCRIPTION
resolves #144 


### Description

Adds a `DIFF` mode to record. 

Expected format: `DBT_RECORDER_MODE=DIFF DBT_RECORDER_FILE_PATH=recording_old.json dbt run --no-partial-parse`

Diff will record using the same types as the input file and then diff the two files.  It ouputs a `diff.json` with the results.  Current state is just json that's reasonably readable but not what we'd necesary want to shwo as output.  But we could parse it out later.

<details><summary>example `diff.json`</summary>
<p>

```
{
    "GetEnvRecord": {},
    "LoadFileRecord": {
        "values_changed": {
            "root[13]['result']['contents']": {
                "new_value": "select 1 as some new id",
                "old_value": "select 1 as id"
            },
            "root[24]['result']['contents']": {
                "new_value": "-- Edit the comments: Use the `ref` function to select from other models\n\nselect *\nfrom {{ ref('my_first_dbt_model') }}\nwhere id = 1",
                "old_value": "-- Use the `ref` function to select from other models\n\nselect *\nfrom {{ ref('my_first_dbt_model') }}\nwhere id = 1",
                "new_path": "root[23]['result']['contents']",
                "diff": "--- \n+++ \n@@ -1,4 +1,4 @@\n--- Use the `ref` function to select from other models\n+-- Edit the comments: Use the `ref` function to select from other models\n \n select *\n from {{ ref('my_first_dbt_model') }}"
            }
        },
        "iterable_item_removed": {
            "root[23]": {
                "params": {
                    "path": "/Users/emily/projects/basic-dbt/models/example/my_first_dbt_model.sql",
                    "strip": true
                },
                "result": {
                    "contents": "/*\n    Welcome to your first dbt model!\n    Did you know that you can also configure models directly within SQL files?\n    This will override configurations stated in dbt_project.yml\n\n    Try changing \"table\" to \"view\" below\n*/\n\n{{ config(materialized='table') }}\n\nwith source_data as (\n\n    select 1 as id\n    union all\n    select null as id\n\n)\n\nselect *\nfrom source_data\n\n/*\n    Uncomment the line below to remove records with null `id` values\n*/\n\n-- where id is not null"
                }
            }
        }
    },
    "FindMatchingRecord": {
        "iterable_item_removed": {
            "root[0]": {
                "params": {
                    "root_path": "/Users/emily/projects/basic-dbt",
                    "relative_paths_to_search": [
                        "macros"
                    ],
                    "file_pattern": "[!.#~]*.sql"
                },
                "result": {
                    "matches": [
                        {
                            "searched_path": "macros",
                            "absolute_path": "/Users/emily/projects/basic-dbt/macros/lots_of_macros.sql",
                            "relative_path": "lots_of_macros.sql",
                            "modification_time": 1717083600.9987388
                        }
                    ]
                }
            }
        }
    },
    "WriteFileRecord": {},
    "QueryRecord": {}
}
```

</p>
</details>

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-common/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-common/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
 
