### PR TITLE
conditionally import deepdiff

### DIFF
--- a/dbt_common/record.py
+++ b/dbt_common/record.py
@@ -10,7 +10,6 @@ import dataclasses
 import json
 import os
 
-from deepdiff import DeepDiff  # type: ignore
 from enum import Enum
 from typing import Any, Callable, Dict, List, Mapping, Optional, Type
 
@@ -52,6 +51,11 @@ class Record:
 
 class Diff:
     def __init__(self, current_recording_path: str, previous_recording_path: str) -> None:
+        # deepdiff is expensive to import, so we only do it here when we need it
+        from deepdiff import DeepDiff  # type: ignore
+
+        self.diff = DeepDiff
+
         self.current_recording_path = current_recording_path
         self.previous_recording_path = previous_recording_path
 
@@ -67,7 +71,7 @@ class Diff:
             if previous[i].get("result").get("table") is not None:
                 previous[i]["result"]["table"] = json.loads(previous[i]["result"]["table"])
 
-        return DeepDiff(previous, current, ignore_order=True, verbose_level=2)
+        return self.diff(previous, current, ignore_order=True, verbose_level=2)
 
     def diff_env_records(self, current: List, previous: List) -> Dict[str, Any]:
         # The mode and filepath may change.  Ignore them.
@@ -77,12 +81,12 @@ class Diff:
             "root[0]['result']['env']['DBT_RECORDER_MODE']",
         ]
 
-        return DeepDiff(
+        return self.diff(
             previous, current, ignore_order=True, verbose_level=2, exclude_paths=exclude_paths
         )
 
     def diff_default(self, current: List, previous: List) -> Dict[str, Any]:
-        return DeepDiff(previous, current, ignore_order=True, verbose_level=2)
+        return self.diff(previous, current, ignore_order=True, verbose_level=2)
 
     def calculate_diff(self) -> Dict[str, Any]:
         with open(self.current_recording_path) as current_recording:


### PR DESCRIPTION

### Description

Conditionally import DeepDiff only when we need to diff.  it uses a lot of memory even when we don't need it.

Always importing DeepDiff
![Screenshot 2024-07-09 at 9 55 32 AM](https://github.com/dbt-labs/dbt-common/assets/7070049/1c866a4b-e63a-4222-bc1a-476bc48146a4)

After adding the conditional import:
![Screenshot 2024-07-09 at 9 55 48 AM](https://github.com/dbt-labs/dbt-common/assets/7070049/74c79bb3-3ac6-49a8-91be-19e26ebb81ef)


### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-common/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-common/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
 
