### PR TITLE
Do not cast unscrubbed values to a string

### DIFF
--- a/.changes/unreleased/Fixes-20240709-190235.yaml
+++ b/.changes/unreleased/Fixes-20240709-190235.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Do not cast unscrubbed values to a string
+time: 2024-07-09T19:02:35.755277-06:00
+custom:
+  Author: dbeatty10
+  Issue: "165"

--- a/dbt_common/exceptions/base.py
+++ b/dbt_common/exceptions/base.py
@@ -10,13 +10,13 @@ def env_secrets() -> List[str]:
     return [v for k, v in os.environ.items() if k.startswith(SECRET_ENV_PREFIX) and v.strip()]
 
 
-def scrub_secrets(msg: str, secrets: List[str]) -> str:
+def scrub_secrets(msg: Any, secrets: List[str]) -> Any:
     scrubbed = str(msg)
 
     for secret in secrets:
         scrubbed = scrubbed.replace(secret, "*****")
 
-    return scrubbed
+    return msg if str(msg) == scrubbed else scrubbed
 
 
 class DbtBaseException(Exception):


### PR DESCRIPTION
resolves #10421

### Problem

The [`scrub_secrets`](https://github.com/dbt-labs/dbt-common/blob/feda22dc08950efb21e4ae4feb1b4fd20a9b090b/dbt_common/exceptions/base.py#L13-L19) method casts all input to `str` systematically, and https://github.com/dbt-labs/dbt-core/pull/9733 applies the scrubbing function to all CLI variables.

This can create issues during `dbt retry` because all values other than `str` will have their data type changed.

### Solution

Leave values as-is during the scrubbing process _unless_ they contain a secret that is scrubbed out.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-common/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-common/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)