### PR TITLE
Fix case-insensitive env vars for Windows

### DIFF
--- a/.changes/unreleased/Fixes-20240715-205355.yaml
+++ b/.changes/unreleased/Fixes-20240715-205355.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix case-insensitive env vars for Windows
+time: 2024-07-15T20:53:55.946355+01:00
+custom:
+    Author: peterallenwebb aranke
+    Issue: "166"

--- a/dbt_common/context.py
+++ b/dbt_common/context.py
@@ -24,13 +24,23 @@ class CaseInsensitiveMapping(Mapping):
 class InvocationContext:
     def __init__(self, env: Mapping[str, str]):
         self._env: Mapping[str, str]
+
+        env_public = {}
+        env_private = {}
+
+        for k, v in env.items():
+            if k.startswith(PRIVATE_ENV_PREFIX):
+                env_private[k] = v
+            else:
+                env_public[k] = v
+
         if os.name == "nt":
-            self._env = CaseInsensitiveMapping({k: v for k, v in env.items() if not k.startswith(PRIVATE_ENV_PREFIX)})
+            self._env = CaseInsensitiveMapping(env_public)
         else:
-            self._env = {k: v for k, v in env.items() if not k.startswith(PRIVATE_ENV_PREFIX)}
+            self._env = env_public
 
         self._env_secrets: Optional[List[str]] = None
-        self._env_private = {k: v for k, v in env.items() if k.startswith(PRIVATE_ENV_PREFIX)}
+        self._env_private = env_private
         self.recorder: Optional[Recorder] = None
         # This class will also eventually manage the invocation_id, flags, event manager, etc.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,6 +126,7 @@ ignore = ["E203", "E501", "E741", "W503", "W504"]
 exclude = [
     "dbt_common/events/types_pb2.py",
     "venv",
+    ".venv",
     "env*"
 ]
 per-file-ignores = ["*/__init__.py: F401"]

--- a/tests/unit/test_invocation_context.py
+++ b/tests/unit/test_invocation_context.py
@@ -12,7 +12,9 @@ def test_invocation_context_env() -> None:
     assert ic.env == test_env
 
 
-@pytest.mark.skipif(os.name != "nt")
+@pytest.mark.skipif(
+    os.name != "nt", reason="Test for case-insensitive env vars, only run on Windows"
+)
 def test_invocation_context_windows() -> None:
     test_env = {"var_1": "lowercase", "vAr_2": "mixedcase", "VAR_3": "uppercase"}
     ic = InvocationContext(env=test_env)

--- a/tests/unit/test_invocation_context.py
+++ b/tests/unit/test_invocation_context.py
@@ -1,11 +1,24 @@
+import os
+
+import pytest
+
 from dbt_common.constants import PRIVATE_ENV_PREFIX, SECRET_ENV_PREFIX
-from dbt_common.context import InvocationContext
+from dbt_common.context import InvocationContext, CaseInsensitiveMapping
 
 
 def test_invocation_context_env() -> None:
     test_env = {"VAR_1": "value1", "VAR_2": "value2"}
     ic = InvocationContext(env=test_env)
     assert ic.env == test_env
+
+
+@pytest.mark.skipif(os.name != "nt")
+def test_invocation_context_windows() -> None:
+    test_env = {"var_1": "lowercase", "vAr_2": "mixedcase", "VAR_3": "uppercase"}
+    ic = InvocationContext(env=test_env)
+    assert ic.env == CaseInsensitiveMapping(
+        {"var_1": "lowercase", "var_2": "mixedcase", "var_3": "uppercase"}
+    )
 
 
 def test_invocation_context_secrets() -> None:


### PR DESCRIPTION
### Description

Add a new `CaseInsensitiveMapping` class and use that for env vars on Windows.
Add a test to verify this case-insensitive mapping.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-common/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development, and it appears to resolve the stated issue
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-common/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
 
