### PR TITLE
Make extract_top_level_blocks() faster

### DIFF
--- a/.changes/unreleased/Under the Hood-20240910-153447.yaml
+++ b/.changes/unreleased/Under the Hood-20240910-153447.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Improve docs parsing performance.
+time: 2024-09-10T15:34:47.389953+02:00
+custom:
+    Author: fredriv
+    Issue: "9037"

--- a/dbt_common/clients/_jinja_blocks.py
+++ b/dbt_common/clients/_jinja_blocks.py
@@ -144,7 +144,6 @@ class TagIterator:
         self.pos -= amount
 
     def _search(self, pattern) -> Optional[re.Match]:
-
         # Check to see if we have a cached search on this pattern.
         positioned_match = self._past_matches.get(pattern)
 


### PR DESCRIPTION
Resolves https://github.com/dbt-labs/dbt-core/issues/9037

### Description

This PR improves the performance of parsing docs files.
Duplicates the change from https://github.com/dbt-labs/dbt-core/pull/9045 into dbt-common

Have verified the performance improvement in our local dbt project (~2300 models). Full parse time on my M1 Mac went from 2m20s to 41s.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-common/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-common/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
 
