### PR TITLE
restrict behavior flags to firing a warning only the first time

### DIFF
--- a/.changes/unreleased/Fixes-20240920-165607.yaml
+++ b/.changes/unreleased/Fixes-20240920-165607.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Restrict behavior change warning to firing once per run to avoid noisy warnings
+  in logs
+time: 2024-09-20T16:56:07.951544-04:00
+custom:
+  Author: mikealfare
+  Issue: "197"

--- a/dbt_common/behavior_flags.py
+++ b/dbt_common/behavior_flags.py
@@ -46,6 +46,8 @@ class BehaviorFlagRendered:
         user_overrides: a set of user settings, one of which may be an override on this behavior flag
     """
 
+    fired: bool = False
+
     def __init__(self, flag: BehaviorFlag, user_overrides: Dict[str, Any]) -> None:
         self._validate(flag)
 
@@ -72,8 +74,9 @@ class BehaviorFlagRendered:
 
     @property
     def setting(self) -> bool:
-        if self._setting is False:
+        if self._setting is False and not self.fired:
             fire_event(self._behavior_change_event)
+            self.fired = True
         return self._setting
 
     @setting.setter

--- a/tests/unit/test_behavior_flags.py
+++ b/tests/unit/test_behavior_flags.py
@@ -171,3 +171,35 @@ def test_behavior_flags_no_behavior_change_event_on_no_warn(event_catcher: Event
 def test_behavior_flag_requires_description_or_docs_url(event_catcher: EventCatcher) -> None:
     with pytest.raises(DbtInternalError):
         Behavior([{"name": "flag_false", "default": False}], {})
+
+
+def test_behavior_flags_fire_once_per_flag(event_catcher: EventCatcher) -> None:
+    behavior = Behavior(
+        [
+            {"name": "flag_1", "default": False, "description": "This is flag 1."},
+            {"name": "flag_2", "default": False, "description": "This is flag 2."},
+        ],
+        {},
+    )
+
+    assert len(event_catcher.caught_events) == 0
+
+    # trigger the evaluation for flag_1, an event should fire
+    if behavior.flag_1:
+        pass
+    assert len(event_catcher.caught_events) == 1
+
+    # trigger the evaluation for flag_1 again, no event should fire
+    if behavior.flag_1:
+        pass
+    assert len(event_catcher.caught_events) == 1
+
+    # trigger the evaluation for flag_2, an event should fire
+    if behavior.flag_2:
+        pass
+    assert len(event_catcher.caught_events) == 2
+
+    # trigger the evaluation for flag_1 again, no event should fire
+    if behavior.flag_1:
+        pass
+    assert len(event_catcher.caught_events) == 2


### PR DESCRIPTION
resolves https://github.com/dbt-labs/dbt-redshift/issues/915

### Description

We're firing a warning per model for behavior changes. We should fire a warning per run.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-common/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-common/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
 
