### PR TITLE
Re-enable suppression of logging event dictionary parsing errors

### DIFF
--- a/.changes/unreleased/Fixes-20241010-164116.yaml
+++ b/.changes/unreleased/Fixes-20241010-164116.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Suppress logging event dictionary parsing exceptions
+time: 2024-10-10T16:41:16.06107-04:00
+custom:
+  Author: gshank
+  Issue: "202"

--- a/tests/unit/test_events.py
+++ b/tests/unit/test_events.py
@@ -1,4 +1,5 @@
 import re
+import os
 
 import pytest
 
@@ -127,11 +128,12 @@ def test_bad_serialization():
     that bad serializations are properly handled, the best we can do is test
     that the exception handling path is used.
     """
-
     with pytest.raises(Exception) as excinfo:
         types.Note(param_event_doesnt_have="This should break")
+    assert 'has no field named "param_event_doesnt_have" at "Note"' in str(excinfo.value)
 
-    assert (
-        str(excinfo.value)
-        == "[Note]: Unable to parse dict {'param_event_doesnt_have': 'This should break'}"
-    )
+    # With this unset, it shouldn't throw an exception
+    saved = os.environ["PYTEST_CURRENT_TEST"]
+    del os.environ["PYTEST_CURRENT_TEST"]
+    types.Note(param_event_doesnt_have="This should not break")
+    os.environ["PYTEST_CURRENT_TEST"] = saved


### PR DESCRIPTION
resolves #202

### Description

Instead of using sys.modules to detect the presence of pytest, use the "PYTEST_CURRENT_TEST" environment variable. Also include the original exception in the logged error for easier debugging.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-common/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-common/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
 
