### PR TITLE
Add Syntax Support for Types on Macro Parameters

### DIFF
--- a/.changes/unreleased/Features-20241210-144247.yaml
+++ b/.changes/unreleased/Features-20241210-144247.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Add syntax support for types on macro parameters.
+time: 2024-12-10T14:42:47.253157-05:00
+custom:
+  Author: peterallenwebb
+  Issue: "229"

--- a/dbt_common/clients/jinja.py
+++ b/dbt_common/clients/jinja.py
@@ -113,8 +113,8 @@ class MacroFuzzParser(jinja2.parser.Parser):
         setattr(node, "arg_types", [])
         setattr(node, "has_type_annotations", False)
 
-        args = node.args = []
-        defaults = node.defaults = []
+        args = node.args = []  # type: ignore
+        defaults = node.defaults = []  # type: ignore
 
         self.stream.expect("lparen")
         while self.stream.current.type != "rparen":

--- a/tests/unit/test_jinja.py
+++ b/tests/unit/test_jinja.py
@@ -2,7 +2,13 @@ import jinja2
 import unittest
 
 from dbt_common.clients._jinja_blocks import BlockTag
-from dbt_common.clients.jinja import extract_toplevel_blocks, get_template, render_template, MacroFuzzParser, MacroType
+from dbt_common.clients.jinja import (
+    extract_toplevel_blocks,
+    get_template,
+    render_template,
+    MacroFuzzParser,
+    MacroType,
+)
 from dbt_common.exceptions import CompilationError
 
 
@@ -506,7 +512,7 @@ hi
 """
 
 
-def test_if_list_filter():
+def test_if_list_filter() -> None:
     jinja_string = """
         {%- if my_var | is_list -%}
             Found a list
@@ -557,4 +563,6 @@ def test_macro_parser_parses_complex_types() -> None:
     assert arg_types[0] == MacroType("List", [MacroType("str")])
     assert arg_types[1] == MacroType("Dict", [MacroType("int"), MacroType("str")])
     assert arg_types[2] == MacroType("Optional", [MacroType("List", [MacroType("str")])])
-    assert arg_types[3] == MacroType("Dict", [MacroType("str"), MacroType("Dict", [MacroType("bool"), MacroType("Any")])])
+    assert arg_types[3] == MacroType(
+        "Dict", [MacroType("str"), MacroType("Dict", [MacroType("bool"), MacroType("Any")])]
+    )

--- a/tests/unit/test_jinja.py
+++ b/tests/unit/test_jinja.py
@@ -1,7 +1,8 @@
+import jinja2
 import unittest
 
 from dbt_common.clients._jinja_blocks import BlockTag
-from dbt_common.clients.jinja import extract_toplevel_blocks, get_template, render_template
+from dbt_common.clients.jinja import extract_toplevel_blocks, get_template, render_template, MacroFuzzParser, MacroType
 from dbt_common.exceptions import CompilationError
 
 
@@ -524,3 +525,36 @@ def test_if_list_filter():
     template = get_template(jinja_string, ctx)
     rendered = render_template(template, ctx)
     assert "Did not find a list" in rendered
+
+
+def test_macro_parser_parses_simple_types() -> None:
+    macro_txt = """
+    {% macro test_macro(param1: str, param2: int, param3: bool, param4: float, param5: Any) %}
+    {% endmacro %}
+    """
+
+    env = jinja2.Environment()
+    parser = MacroFuzzParser(env, macro_txt)
+    result = parser.parse()
+    arg_types = result.body[1].arg_types
+    assert arg_types[0] == MacroType("str")
+    assert arg_types[1] == MacroType("int")
+    assert arg_types[2] == MacroType("bool")
+    assert arg_types[3] == MacroType("float")
+    assert arg_types[4] == MacroType("Any")
+
+
+def test_macro_parser_parses_complex_types() -> None:
+    macro_txt = """
+    {% macro test_macro(param1: List[str], param2: Dict[ int,str ], param3: Optional[List[str]], param4: Dict[str, Dict[bool, Any]]) %}
+    {% endmacro %}
+    """
+
+    env = jinja2.Environment()
+    parser = MacroFuzzParser(env, macro_txt)
+    result = parser.parse()
+    arg_types = result.body[1].arg_types
+    assert arg_types[0] == MacroType("List", [MacroType("str")])
+    assert arg_types[1] == MacroType("Dict", [MacroType("int"), MacroType("str")])
+    assert arg_types[2] == MacroType("Optional", [MacroType("List", [MacroType("str")])])
+    assert arg_types[3] == MacroType("Dict", [MacroType("str"), MacroType("Dict", [MacroType("bool"), MacroType("Any")])])

--- a/tests/unit/test_jinja.py
+++ b/tests/unit/test_jinja.py
@@ -1,6 +1,8 @@
 import jinja2
 import unittest
 
+from typing import Any, Dict
+
 from dbt_common.clients._jinja_blocks import BlockTag
 from dbt_common.clients.jinja import (
     extract_toplevel_blocks,
@@ -521,7 +523,7 @@ def test_if_list_filter() -> None:
         {%- endif -%}
     """
     # Check with list variable
-    ctx = {"my_var": ["one", "two"]}
+    ctx: Dict[str, Any] = {"my_var": ["one", "two"]}
     template = get_template(jinja_string, ctx)
     rendered = render_template(template, ctx)
     assert "Found a list" in rendered


### PR DESCRIPTION
Partially implements: https://github.com/dbt-labs/dbt-core/issues/11090

This change customizes the jinja parser to allow for Python-style type annotations on macro parameters. It does not implement any functionality relying on the type information. That kind of functionality will be implemented in dbt-core.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-common/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-common/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
 
