### PR TITLE
fix: only evaluate modification time on matched local files

### DIFF
--- a/dbt_common/clients/system.py
+++ b/dbt_common/clients/system.py
@@ -127,14 +127,16 @@ def find_matching(
             # if ignore_spec.match(relative_dir):
             #     continue
             for local_file in local_files:
+                if not reobj.match(local_file):
+                    continue
+
                 absolute_path = os.path.join(current_path, local_file)
                 relative_path = os.path.relpath(absolute_path, absolute_path_to_search)
                 relative_path_to_root = os.path.join(relative_path_to_search, relative_path)
 
                 modification_time = os.path.getmtime(absolute_path)
-                if reobj.match(local_file) and (
-                    not ignore_spec or not ignore_spec.match_file(relative_path_to_root)
-                ):
+
+                if not ignore_spec or not ignore_spec.match_file(relative_path_to_root):
                     matching.append(
                         {
                             "searched_path": relative_path_to_search,


### PR DESCRIPTION
contributes to astronomer/astronomer-cosmos#1075

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->

### Description

<!---
  Describe the Pull Request here. Add any references and info to help reviewers
  understand your changes. Include any tradeoffs you considered.
-->

There is a very hard to reproduce race-condition that occurs in some environments where dbt is used on a concurrently accessed filesystem, like Airflow with Celery workers.  The symptom is one process walking the dbt project tree and hitting an error similar to:

```
  File "/usr/local/airflow/dbt_venv/lib/python3.11/site-packages/dbt/parser/search.py", line 74, in filesystem_search
    for result in find_matching(root, relative_dirs, ext, ignore_spec):
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/airflow/dbt_venv/lib/python3.11/site-packages/dbt/clients/system.py", line 79, in find_matching
    modification_time = os.path.getmtime(absolute_path)
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen genericpath>", line 55, in getmtime
FileNotFoundError: [Errno 2] No such file or directory: '/tmp/tmpf6h80niz/models/intermediate/shipment/.int_easy_post_tracking.sql.GgjJgL'
```

It's unclear what actually creates those temp files (I would love to know!), but that error should not even occur, since the filename doesn't match any extension spec that dbt should be searching for.  Note, I've seen these files created for all extensions that dbt would be concerned with (.md, .yml, .sql); it's not a problem localized to just model files or macros.

This PR reorders the operations in `find_matching` such that any file names that don't match the regex pattern are skipped before `getmtime` is even called.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-common/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-common/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
 
