### PR TITLE
Update `fire_event` to handle `warn_or_error` logic

### DIFF
--- a/.changes/unreleased/Breaking Changes-20250117-144053.yaml
+++ b/.changes/unreleased/Breaking Changes-20250117-144053.yaml
@@ -1,0 +1,6 @@
+kind: Breaking Changes
+body: Update `fire_event` to handle `warn_or_error` logic
+time: 2025-01-17T14:40:53.08567-06:00
+custom:
+  Author: QMalcolm
+  Issue: "236"

--- a/dbt_common/events/event_manager.py
+++ b/dbt_common/events/event_manager.py
@@ -16,11 +16,15 @@ class EventManager:
         self.warn_error_options: WarnErrorOptions = WarnErrorOptions(include=[], exclude=[])
 
     def fire_event(
-        self, e: BaseEvent, level: Optional[EventLevel] = None, node: Any = None
+        self,
+        e: BaseEvent,
+        level: Optional[EventLevel] = None,
+        node: Any = None,
+        force_warn_or_error_handling: bool = False,
     ) -> None:
         msg = msg_from_base_event(e, level=level)
 
-        if msg.info.level == "warn":
+        if force_warn_or_error_handling and msg.info.level == "warn":
             event_name = type(e).__name__
             if self.warn_error or self.warn_error_options.includes(event_name):
                 # This has the potential to create an infinite loop if the handling of the raised
@@ -68,7 +72,11 @@ class IEventManager(Protocol):
     warn_error_options: WarnErrorOptions
 
     def fire_event(
-        self, e: BaseEvent, level: Optional[EventLevel] = None, node: Any = None
+        self,
+        e: BaseEvent,
+        level: Optional[EventLevel] = None,
+        node: Any = None,
+        force_warn_or_error_handling: bool = False,
     ) -> None:
         ...
 

--- a/dbt_common/events/event_manager.py
+++ b/dbt_common/events/event_manager.py
@@ -4,12 +4,15 @@ from typing import List, Optional, Protocol, Tuple
 
 from dbt_common.events.base_types import BaseEvent, EventLevel, msg_from_base_event, TCallback
 from dbt_common.events.logger import LoggerConfig, _Logger, _TextLogger, _JsonLogger, LineFormat
+from dbt_common.helper_types import WarnErrorOptions
 
 
 class EventManager:
     def __init__(self) -> None:
         self.loggers: List[_Logger] = []
         self.callbacks: List[TCallback] = []
+        self.warn_error: bool = False
+        self.warn_error_options: WarnErrorOptions = WarnErrorOptions(include=[], exclude=[])
 
     def fire_event(self, e: BaseEvent, level: Optional[EventLevel] = None) -> None:
         msg = msg_from_base_event(e, level=level)
@@ -48,6 +51,8 @@ class EventManager:
 class IEventManager(Protocol):
     callbacks: List[TCallback]
     loggers: List[_Logger]
+    warn_error: bool
+    warn_error_options: WarnErrorOptions
 
     def fire_event(self, e: BaseEvent, level: Optional[EventLevel] = None) -> None:
         ...

--- a/dbt_common/events/event_manager.py
+++ b/dbt_common/events/event_manager.py
@@ -14,6 +14,7 @@ class EventManager:
         self.callbacks: List[TCallback] = []
         self.warn_error: bool = False
         self.warn_error_options: WarnErrorOptions = WarnErrorOptions(include=[], exclude=[])
+        self.require_warn_or_error_handling: bool = False
 
     def fire_event(
         self,
@@ -24,7 +25,9 @@ class EventManager:
     ) -> None:
         msg = msg_from_base_event(e, level=level)
 
-        if force_warn_or_error_handling and msg.info.level == "warn":
+        if (
+            force_warn_or_error_handling or self.require_warn_or_error_handling
+        ) and msg.info.level == "warn":
             event_name = type(e).__name__
             if self.warn_error or self.warn_error_options.includes(event_name):
                 # This has the potential to create an infinite loop if the handling of the raised
@@ -70,6 +73,7 @@ class IEventManager(Protocol):
     loggers: List[_Logger]
     warn_error: bool
     warn_error_options: WarnErrorOptions
+    require_warn_or_error_handling: bool
 
     def fire_event(
         self,

--- a/dbt_common/events/functions.py
+++ b/dbt_common/events/functions.py
@@ -112,7 +112,7 @@ def msg_to_dict(msg: EventMsg) -> dict:
 
 # This function continues to exist to provide backwards compatibility
 def warn_or_error(event, node=None) -> None:
-    fire_event(e=event, node=node)
+    fire_event(e=event, node=node, force_warn_or_error_handling=True)
 
 
 # an alternative to fire_event which only creates and logs the event value
@@ -128,8 +128,15 @@ def fire_event_if(
 # this is where all the side effects happen branched by event type
 # (i.e. - mutating the event history, printing to stdout, logging
 # to files, etc.)
-def fire_event(e: BaseEvent, level: Optional[EventLevel] = None, node: Any = None) -> None:
-    get_event_manager().fire_event(e, level=level, node=node)
+def fire_event(
+    e: BaseEvent,
+    level: Optional[EventLevel] = None,
+    node: Any = None,
+    force_warn_or_error_handling: bool = False,
+) -> None:
+    get_event_manager().fire_event(
+        e, level=level, node=node, force_warn_or_error_handling=force_warn_or_error_handling
+    )
 
 
 def get_metadata_vars() -> Dict[str, str]:

--- a/tests/unit/test_functions.py
+++ b/tests/unit/test_functions.py
@@ -3,7 +3,7 @@ import pytest
 from dbt_common.events import functions
 from dbt_common.events.base_types import EventLevel, WarnLevel
 from dbt_common.events.event_manager import EventManager
-from dbt_common.events.event_manager_client import ctx_set_event_manager
+from dbt_common.events.event_manager_client import ctx_set_event_manager, get_event_manager
 from dbt_common.exceptions import EventCompilationError
 from dbt_common.helper_types import WarnErrorOptions
 from tests.unit.utils import EventCatcher
@@ -40,7 +40,7 @@ def valid_error_names() -> Set[str]:
 
 class TestWarnOrError:
     def test_fires_error(self, valid_error_names: Set[str]) -> None:
-        functions.WARN_ERROR_OPTIONS = WarnErrorOptions(
+        get_event_manager().warn_error_options = WarnErrorOptions(
             include="*", valid_error_names=valid_error_names
         )
         with pytest.raises(EventCompilationError):
@@ -52,7 +52,7 @@ class TestWarnOrError:
         event_catcher: EventCatcher,
         set_event_manager_with_catcher: None,
     ) -> None:
-        functions.WARN_ERROR_OPTIONS = WarnErrorOptions(
+        get_event_manager().warn_error_options = WarnErrorOptions(
             include="*", exclude=list(valid_error_names), valid_error_names=valid_error_names
         )
         functions.warn_or_error(Note(msg="hi"))
@@ -65,7 +65,7 @@ class TestWarnOrError:
         event_catcher: EventCatcher,
         set_event_manager_with_catcher: None,
     ) -> None:
-        functions.WARN_ERROR_OPTIONS = WarnErrorOptions(
+        get_event_manager().warn_error_options = WarnErrorOptions(
             include="*", silence=list(valid_error_names), valid_error_names=valid_error_names
         )
         functions.warn_or_error(Note(msg="hi"))

--- a/tests/unit/test_functions.py
+++ b/tests/unit/test_functions.py
@@ -40,19 +40,24 @@ def valid_error_names() -> Set[str]:
 
 class TestFireEvent:
     @pytest.mark.parametrize(
-        "force_warn_or_error_handling,should_raise",
+        "force_warn_or_error_handling,require_warn_or_error_handling,should_raise",
         [
-            (True, True),
-            (False, False),
+            (True, True, True),
+            (True, False, True),
+            (False, True, True),
+            (False, False, False),
         ],
     )
     def test_warning_handling(
         self,
         set_event_manager_with_catcher: None,
         force_warn_or_error_handling: bool,
+        require_warn_or_error_handling: bool,
         should_raise: bool,
     ) -> None:
-        get_event_manager().warn_error = True
+        manager = get_event_manager()
+        manager.warn_error = True
+        manager.require_warn_or_error_handling = require_warn_or_error_handling
         try:
             functions.fire_event(
                 e=Note(msg="hi"), force_warn_or_error_handling=force_warn_or_error_handling

--- a/tests/unit/test_functions.py
+++ b/tests/unit/test_functions.py
@@ -38,7 +38,37 @@ def valid_error_names() -> Set[str]:
     return {Note.__name__}
 
 
-class TestWarnOrError:
+class TestFireEvent:
+    @pytest.mark.parametrize(
+        "force_warn_or_error_handling,should_raise",
+        [
+            (True, True),
+            (False, False),
+        ],
+    )
+    def test_warning_handling(
+        self,
+        set_event_manager_with_catcher: None,
+        force_warn_or_error_handling: bool,
+        should_raise: bool,
+    ) -> None:
+        get_event_manager().warn_error = True
+        try:
+            functions.fire_event(
+                e=Note(msg="hi"), force_warn_or_error_handling=force_warn_or_error_handling
+            )
+        except EventCompilationError:
+            assert (
+                should_raise
+            ), "`fire_event` raised an error from a warning when it shouldn't have"
+            return
+
+        assert (
+            not should_raise
+        ), "`fire_event` didn't raise an error from a warning when it should have"
+
+
+class TestDeprecatedWarnOrError:
     def test_fires_error(self, valid_error_names: Set[str]) -> None:
         get_event_manager().warn_error_options = WarnErrorOptions(
             include="*", valid_error_names=valid_error_names


### PR DESCRIPTION
resolves #236 

### Description

In https://github.com/dbt-labs/dbt-core/issues/11116 we have resolved to allow people to opt in to having all warnings be handled by the logic of the [warn_or_error function](https://github.com/dbt-labs/dbt-common/blob/2253401254d0ef6b819415b6a2546de3e16e5d95/dbt_common/events/functions.py#L117). There are a few ways we could have solved this
1. Update every `warn` level event currently fired with `fire_event` to be conditionally either fired with `warn_or_error` or `fire_event` based on a behavior flag
2. Have core implement its own `fire_event` helper which does what is described in (1) for every warn passed into it (an then updated every call to dbt-common's `fire_event` to instead be dbt-core's `fire_event`
3. Update dbt-common's `fire_event` to optionally put every `warn` even through the `warn_or_error` logic depending on a behavior flag
4. Do (2) or (3) but instead of a single behavior flag, a behavior flag per warn level event / cohorts of warn level events

This PR implements option (3), as I believe (3) to be less error-prone than (1), and (3) only requires implementing in one area whereas (2) would have to be implemented in multiple code abses. We have discussed whether it was worthwhile to do (4), and for awhile we were leaning that direction. However, we have decided that there will only be one behavior flag, and at some point that behavior flag will go away. That is, at some point all warnings will be handled by the warn_or_error logic flow. Thus it makes sense to stick with (3), what this PR implements

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-common/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [X] I have run this code in development and it appears to resolve the stated issue
- [X] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [X] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-common/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
 
