### PR TITLE
Add '@auto_record_function' for less verbose record/replay annotaitons

### DIFF
--- a/.changes/unreleased/Features-20250124-164923.yaml
+++ b/.changes/unreleased/Features-20250124-164923.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Add '@auto_record_function' for less verbose record/replay annotaitons
+time: 2025-01-24T16:49:23.097806-05:00
+custom:
+    Author: peterallenwebb
+    Issue: "240"

--- a/tests/unit/test_record.py
+++ b/tests/unit/test_record.py
@@ -213,10 +213,6 @@ def test_auto_decorator_records(setup) -> None:
 
     test_func(123, "abc")
 
-    expected_record = TestRecord(
-        params=TestRecordParams(123, "abc"), result=TestRecordResult("123abc")
-    )
-
     assert recorder._records_by_type["TestAutoRecord"][-1].params.a == 123
     assert recorder._records_by_type["TestAutoRecord"][-1].params.b == "abc"
     assert recorder._records_by_type["TestAutoRecord"][-1].result.return_val == "123abc"

--- a/tests/unit/test_record.py
+++ b/tests/unit/test_record.py
@@ -4,7 +4,7 @@ import pytest
 from typing import Optional
 
 from dbt_common.context import set_invocation_context, get_invocation_context
-from dbt_common.record import record_function, Record, Recorder, RecorderMode
+from dbt_common.record import record_function, Record, Recorder, RecorderMode, auto_record_function
 
 
 @dataclasses.dataclass
@@ -199,3 +199,24 @@ def test_nested_recording_replay(setup) -> None:
 
     result = outer_func(123, "abc")
     assert result == "123abc124abc"
+
+
+def test_auto_decorator_records(setup) -> None:
+    os.environ["DBT_RECORDER_MODE"] = "Record"
+    recorder = Recorder(RecorderMode.RECORD, None)
+    set_invocation_context({})
+    get_invocation_context().recorder = recorder
+
+    @auto_record_function("TestAuto")
+    def test_func(a: int, b: str, c: Optional[str] = None) -> str:
+        return str(a) + b + (c if c else "")
+
+    test_func(123, "abc")
+
+    expected_record = TestRecord(
+        params=TestRecordParams(123, "abc"), result=TestRecordResult("123abc")
+    )
+
+    assert recorder._records_by_type["TestAutoRecord"][-1].params.a == 123
+    assert recorder._records_by_type["TestAutoRecord"][-1].params.b == "abc"
+    assert recorder._records_by_type["TestAutoRecord"][-1].result.return_val == "123abc"


### PR DESCRIPTION
### Description

Automatically generate default implementations of the Record/Params/Result classes for simple functions.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-common/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-common/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
 
