### PR TITLE
Add "invocation_started_at" global field

### DIFF
--- a/.changes/unreleased/Features-20250213-135245.yaml
+++ b/.changes/unreleased/Features-20250213-135245.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Add "invocation_started_at" global field
+time: 2025-02-13T13:52:45.156677-05:00
+custom:
+  Author: gshank
+  Issue: "245"

--- a/dbt_common/invocation.py
+++ b/dbt_common/invocation.py
@@ -1,12 +1,19 @@
 import uuid
+from datetime import datetime
 
 _INVOCATION_ID = str(uuid.uuid4())
+_INVOCATION_STARTED_AT = datetime.utcnow()
 
 
 def get_invocation_id() -> str:
     return _INVOCATION_ID
 
 
+def get_invocation_started_at() -> datetime:
+    return _INVOCATION_STARTED_AT
+
+
 def reset_invocation_id() -> None:
-    global _INVOCATION_ID
+    global _INVOCATION_ID, _INVOCATION_STARTED_AT
     _INVOCATION_ID = str(uuid.uuid4())
+    _INVOCATION_STARTED_AT = datetime.utcnow()

--- a/tests/unit/test_invocation.py
+++ b/tests/unit/test_invocation.py
@@ -1,0 +1,12 @@
+from dbt_common.invocation import get_invocation_id, get_invocation_started_at, reset_invocation_id
+
+
+def test_invocation_started_at():
+    inv_id = get_invocation_id()
+    assert inv_id
+    inv_start = get_invocation_started_at()
+    assert inv_start
+
+    reset_invocation_id()
+    inv_start != get_invocation_started_at()
+    inv_id != get_invocation_id()


### PR DESCRIPTION
resolves #245

### Description

Add new global "invocation_started_at" which is created and reset at the same time as "invocation_id".

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-common/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-common/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
 
