### PR TITLE
Allow Manually Recorded Functions to Use Automatic Thread ID

### DIFF
--- a/dbt_common/record.py
+++ b/dbt_common/record.py
@@ -361,6 +361,7 @@ def record_function(
     method: bool = False,
     tuple_result: bool = False,
     id_field_name: Optional[str] = None,
+    index_on_thread_id: bool = True,
 ) -> Callable:
     """This is the @record_function decorator, which marks functions which will
     have their function calls recorded during record mode, and mocked out with
@@ -372,7 +373,7 @@ def record_function(
         tuple_result,
         id_field_name,
         None,
-        False,
+        index_on_thread_id,
         False,
     )
 

--- a/dbt_common/record.py
+++ b/dbt_common/record.py
@@ -361,7 +361,7 @@ def record_function(
     method: bool = False,
     tuple_result: bool = False,
     id_field_name: Optional[str] = None,
-    index_on_thread_id: bool = True,
+    index_on_thread_id: bool = False,
 ) -> Callable:
     """This is the @record_function decorator, which marks functions which will
     have their function calls recorded during record mode, and mocked out with


### PR DESCRIPTION

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-common/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-common/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
 
