### PR TITLE
Stream recorded events to disk rather than storing them in memory.

### DIFF
--- a/.changes/unreleased/Under the Hood-20250321-145149.yaml
+++ b/.changes/unreleased/Under the Hood-20250321-145149.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Stream recorded events to disk rather than storing them in memory.
+time: 2025-03-21T14:51:49.593977-04:00
+custom:
+    Author: peterallenwebb
+    Issue: "260"

--- a/dbt_common/record.py
+++ b/dbt_common/record.py
@@ -151,6 +151,7 @@ class Recorder:
         types: Optional[List],
         current_recording_path: str = "recording.json",
         previous_recording_path: Optional[str] = None,
+        in_memory: bool = False,
     ) -> None:
         self.mode = mode
         self.recorded_types = types
@@ -178,7 +179,7 @@ class Recorder:
 
         self._record_added = False
         self._recording_file: Optional[TextIO] = None
-        if mode == RecorderMode.RECORD:
+        if mode == RecorderMode.RECORD and not in_memory:
             self._recording_file = open(current_recording_path, "w")
             self._recording_file.write("[")
 

--- a/dbt_common/record.py
+++ b/dbt_common/record.py
@@ -176,6 +176,15 @@ class Recorder:
         self._counter = 0
         self._counter_lock = Lock()
 
+        self._record_added = False
+        self._recording_file: Optional[TextIO] = None
+        if mode == RecorderMode.RECORD:
+            self._recording_file = open(current_recording_path, "w")
+            self._recording_file.write("[")
+
+    def __del__(self):
+        self.clean_up_stream()
+
     @classmethod
     def register_record_type(cls, rec_type) -> Any:
         cls._record_cls_by_name[rec_type.__name__] = rec_type
@@ -184,14 +193,21 @@ class Recorder:
 
     def add_record(self, record: Record) -> None:
         rec_cls_name = record.__class__.__name__  # type: ignore
-        if rec_cls_name not in self._records_by_type:
-            self._records_by_type[rec_cls_name] = []
 
         with self._counter_lock:
             record.seq = self._counter
             self._counter += 1
 
-        self._records_by_type[rec_cls_name].append(record)
+        if self._recording_file is not None:
+            if self._record_added:
+                self._recording_file.write(",")
+            dct = Recorder._get_tagged_dict(record, rec_cls_name)
+            json.dump(dct, self._recording_file)
+            self._record_added = True
+        else:
+            if rec_cls_name not in self._records_by_type:
+                self._records_by_type[rec_cls_name] = []
+            self._records_by_type[rec_cls_name].append(record)
 
     def pop_matching_record(self, params: Any) -> Optional[Record]:
         rec_type_name = self._record_name_by_params_name.get(type(params).__name__)
@@ -217,19 +233,30 @@ class Recorder:
         json.dump(d, out_stream)
 
     def write(self) -> None:
-        with open(self.current_recording_path, "w") as file:
-            self.write_json(file)
+        if self._recording_file is not None:
+            self.clean_up_stream()
+        else:
+            with open(self.current_recording_path, "w") as file:
+                self.write_json(file)
+
+    def clean_up_stream(self) -> None:
+        if self._recording_file is not None:
+            self._recording_file.write("]")
+            self._recording_file.close()
+            self._recording_file = None
+
+    @staticmethod
+    def _get_tagged_dict(record: Record, record_type: str) -> Dict:
+        d = record.to_dict()
+        d["type"] = record_type
+        return d
 
     def _to_list(self) -> List[Dict]:
-        def get_tagged_dict(record: Record, record_type: str) -> Dict:
-            d = record.to_dict()
-            d["type"] = record_type
-            return d
-
         record_list: List[Dict] = []
         for record_type in self._records_by_type:
             record_list.extend(
-                get_tagged_dict(r, record_type) for r in self._records_by_type[record_type]
+                Recorder._get_tagged_dict(r, record_type)
+                for r in self._records_by_type[record_type]
             )
 
         record_list.sort(key=lambda r: r["seq"])

--- a/tests/unit/test_record.py
+++ b/tests/unit/test_record.py
@@ -148,18 +148,14 @@ def test_record_types_streamed(setup):
     test_func(123, "abc")
     not_test_func(456, "def")
 
-    expected_record = TestRecord(
-        params=TestRecordParams(123, "abc"), result=TestRecordResult("123abc")
-    )
-
     recorder.write()
 
     rec = {}
     with open("recording.json", "r") as f:
         rec = json.load(f)
 
-    assert rec[-1]["params"] == { "a": 123, "b": "abc", "c": None }
-    assert rec[-1]["result"] == { "return_val" : "123abc" }
+    assert rec[-1]["params"] == {"a": 123, "b": "abc", "c": None}
+    assert rec[-1]["result"] == {"return_val": "123abc"}
     assert NotTestRecord not in recorder._records_by_type
 
 


### PR DESCRIPTION
### Description

Streams recorded events to an open file during recordings, rather than holding them in memory until the end of an invocation.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-common/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-common/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
 
