### PR TITLE
Add warning callback for unexpected endmacro blocks

### DIFF
--- a/dbt_common/clients/_jinja_blocks.py
+++ b/dbt_common/clients/_jinja_blocks.py
@@ -1,7 +1,7 @@
 import dataclasses
 import re
 from collections import namedtuple
-from typing import Dict, Iterator, List, Optional, Set, Union, Callable
+from typing import Callable, Dict, Iterator, List, Optional, Set, Union
 
 from dbt_common.exceptions import (
     BlockDefinitionNotAtTopError,
@@ -406,7 +406,9 @@ class BlockIterator:
                 self.current = None
             elif self.warning_callback:
                 self.warning_callback(
-                    ExtractWarning("unexpected_block", f"Found unexpected '{tag.block_type_name}' block tag.")
+                    ExtractWarning(
+                        "unexpected_block", f"Found unexpected '{tag.block_type_name}' block tag."
+                    )
                 )
 
         if self.current:

--- a/dbt_common/clients/_jinja_blocks.py
+++ b/dbt_common/clients/_jinja_blocks.py
@@ -404,9 +404,9 @@ class BlockIterator:
                     full_block=self.data[self.current.start : tag.end],
                 )
                 self.current = None
-            elif self.warning_callback is not None and tag.block_type_name == "endmacro":
+            elif self.warning_callback:
                 self.warning_callback(
-                    ExtractWarning("unexpected_block", "Found unexpected block tag.")
+                    ExtractWarning("unexpected_block", f"Found unexpected '{tag.block_type_name}' block tag.")
                 )
 
         if self.current:

--- a/dbt_common/clients/_jinja_blocks.py
+++ b/dbt_common/clients/_jinja_blocks.py
@@ -1,7 +1,7 @@
 import dataclasses
 import re
 from collections import namedtuple
-from typing import Dict, Iterator, List, Optional, Set, Union
+from typing import Dict, Iterator, List, Optional, Set, Union, Callable
 
 from dbt_common.exceptions import (
     BlockDefinitionNotAtTopError,
@@ -113,6 +113,12 @@ class PositionedMatch:
 
     start_pos: int
     match: Optional[re.Match]
+
+
+@dataclasses.dataclass
+class ExtractWarning:
+    warning_type: str
+    msg: str
 
 
 class TagIterator:
@@ -326,8 +332,13 @@ _CONTROL_FLOW_END_TAGS = {v: k for k, v in _CONTROL_FLOW_TAGS.items()}
 
 
 class BlockIterator:
-    def __init__(self, tag_iterator: TagIterator) -> None:
+    def __init__(
+        self,
+        tag_iterator: TagIterator,
+        warning_callback: Optional[Callable[[ExtractWarning], None]] = None,
+    ) -> None:
         self.tag_parser = tag_iterator
+        self.warning_callback = warning_callback
         self.current: Optional[Tag] = None
         self.stack: List[str] = []
         self.last_position: int = 0
@@ -393,6 +404,10 @@ class BlockIterator:
                     full_block=self.data[self.current.start : tag.end],
                 )
                 self.current = None
+            elif self.warning_callback is not None and tag.block_type_name == "endmacro":
+                self.warning_callback(
+                    ExtractWarning("unexpected_block", "Found unexpected block tag.")
+                )
 
         if self.current:
             linecount = self.data[: self.current.end].count("\n") + 1

--- a/dbt_common/clients/jinja.py
+++ b/dbt_common/clients/jinja.py
@@ -38,7 +38,13 @@ from dbt_common.utils.jinja import (
     get_materialization_macro_name,
     get_test_macro_name,
 )
-from dbt_common.clients._jinja_blocks import BlockIterator, BlockData, BlockTag, TagIterator
+from dbt_common.clients._jinja_blocks import (
+    BlockIterator,
+    BlockData,
+    BlockTag,
+    TagIterator,
+    ExtractWarning,
+)
 
 from dbt_common.exceptions import (
     CompilationError,
@@ -659,6 +665,7 @@ def extract_toplevel_blocks(
     text: str,
     allowed_blocks: Optional[Set[str]] = None,
     collect_raw_data: bool = True,
+    warning_callback: Optional[Callable[[ExtractWarning], None]] = None,
 ) -> List[Union[BlockData, BlockTag]]:
     """Extract the top-level blocks with matching block types from a jinja file.
 
@@ -672,6 +679,8 @@ def extract_toplevel_blocks(
         be part of the results, as `BlockData` objects. They have a
         `block_type_name` field of `'__dbt_data'` and will never have a
         `block_name`.
+    :param warning_callback: An optional callback that will be called if there
+        are recoverable issues detected in the template.
     :return: A list of `BlockTag`s matching the allowed block types and (if
         `collect_raw_data` is `True`) `BlockData` objects.
     """
@@ -682,7 +691,7 @@ def extract_toplevel_blocks(
             return _TESTING_BLOCKS_CACHE[hash]
 
     tag_iterator = TagIterator(text)
-    blocks = BlockIterator(tag_iterator).lex_for_blocks(
+    blocks = BlockIterator(tag_iterator, warning_callback).lex_for_blocks(
         allowed_blocks=allowed_blocks, collect_raw_data=collect_raw_data
     )
 

--- a/tests/unit/test_jinja.py
+++ b/tests/unit/test_jinja.py
@@ -570,9 +570,9 @@ def test_macro_parser_parses_complex_types() -> None:
     )
 
 
-def test_stray_endmacro_block_warns() -> None:
+def test_stray_block_warnings() -> None:
     problem_template = """
-    {% endmacro %}
+    {% unknown %}
     {% macro foo() %}
     {% endmacro %}
     {% endmacro %}
@@ -589,4 +589,6 @@ def test_stray_endmacro_block_warns() -> None:
     assert len(blocks) == 1
     assert len(warnings) == 2
     assert warnings[0].warning_type == "unexpected_block"
+    assert "unknown" in warnings[0].msg
     assert warnings[1].warning_type == "unexpected_block"
+    assert "endmacro" in warnings[1].msg

--- a/tests/unit/test_jinja.py
+++ b/tests/unit/test_jinja.py
@@ -1,9 +1,9 @@
 import jinja2
 import unittest
 
-from typing import Any, Dict
+from typing import Any, Dict, List
 
-from dbt_common.clients._jinja_blocks import BlockTag
+from dbt_common.clients._jinja_blocks import BlockTag, ExtractWarning
 from dbt_common.clients.jinja import (
     extract_toplevel_blocks,
     get_template,
@@ -568,3 +568,25 @@ def test_macro_parser_parses_complex_types() -> None:
     assert arg_types[3] == MacroType(
         "Dict", [MacroType("str"), MacroType("Dict", [MacroType("bool"), MacroType("Any")])]
     )
+
+
+def test_stray_endmacro_block_warns() -> None:
+    problem_template = """
+    {% endmacro %}
+    {% macro foo() %}
+    {% endmacro %}
+    {% endmacro %}
+    """
+
+    warnings: List[ExtractWarning] = []
+
+    def warning_callback(warning: ExtractWarning):
+        warnings.append(warning)
+
+    blocks = extract_toplevel_blocks(
+        problem_template, collect_raw_data=False, warning_callback=warning_callback
+    )
+    assert len(blocks) == 1
+    assert len(warnings) == 2
+    assert warnings[0].warning_type == "unexpected_block"
+    assert warnings[1].warning_type == "unexpected_block"


### PR DESCRIPTION
### Description

Add warning callback to jinja block parsing, so that core can deprecate existing, over-tolerant behaviors.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-common/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-common/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
 
