### PR TITLE
Remove extra linebreak from deprecation_tag

### DIFF
--- a/dbt_common/ui.py
+++ b/dbt_common/ui.py
@@ -83,7 +83,7 @@ def warning_tag(msg: str) -> str:
 
 
 def deprecation_tag(msg: str) -> str:
-    return warning_tag(f"Deprecated functionality\n\n{msg}")
+    return warning_tag(f"Deprecated functionality\n{msg}")
 
 
 def error_tag(msg: str) -> str:


### PR DESCRIPTION
resolves #N/A

### Description

The double line break in deprecation warnings look bad and make it harder to parse the logs. Instead we should do a single line break.

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-common/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [X] I have run this code in development and it appears to resolve the stated issue
- [X] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [X] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-common/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
 
