### PR TITLE
Ensure `fire_event` allows for the silencing of deprecations

### DIFF
--- a/.changes/unreleased/Fixes-20250418-094950.yaml
+++ b/.changes/unreleased/Fixes-20250418-094950.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Ensure `fire_event` allows for the silencing of deprecations
+time: 2025-04-18T09:49:50.164836-07:00
+custom:
+  Author: QMalcolm
+  Issue: "276"

--- a/dbt_common/events/event_manager.py
+++ b/dbt_common/events/event_manager.py
@@ -52,12 +52,11 @@ class EventManager:
         if force_warn_or_error_handling or (
             self.require_warn_or_error_handling and msg.info.level == "warn"
         ):
-            event_name = type(e).__name__
-            if self.warn_error or self.warn_error_options.includes(event_name):
+            if self.warn_error or self.warn_error_options.includes(e):
                 # This has the potential to create an infinite loop if the handling of the raised
                 # EventCompilationError fires an event as a warning instead of an error.
                 raise EventCompilationError(e.message(), node)
-            elif self.warn_error_options.silenced(event_name):
+            elif self.warn_error_options.silenced(e):
                 # Return early if the event is silenced
                 return
 

--- a/tests/unit/test_event_manager.py
+++ b/tests/unit/test_event_manager.py
@@ -1,4 +1,5 @@
 from dbt_common.events.event_manager import EventManager
+from dbt_common.events.types import BehaviorChangeEvent
 from tests.unit.utils import EventCatcher
 
 
@@ -9,3 +10,25 @@ class TestEventManager:
 
         event_manager.add_callback(EventCatcher().catch)
         assert len(event_manager.callbacks) == 1
+
+
+class TestEventManagerSilencedDeprecation:
+    def test_can_silenced_deprecation_event(self) -> None:
+        event_catcher = EventCatcher()
+        event_manager = EventManager()
+        event_manager.add_callback(event_catcher.catch)
+
+        event = BehaviorChangeEvent(
+            flag_name="test",
+            flag_source="test",
+            description="test",
+            docs_url="test",
+        )
+
+        event_manager.fire_event(e=event, force_warn_or_error_handling=True)
+        assert len(event_manager.callbacks) == 1
+
+        event_catcher.caught_events.clear()
+        event_manager.warn_error_options.silence.append("Deprecations")
+        event_manager.fire_event(e=event, force_warn_or_error_handling=True)
+        assert len(event_catcher.caught_events) == 0


### PR DESCRIPTION
resolves #276

### Description

Deprecations weren't being silenced when fired via `warn_error` or `fire_event`. This was because even if `Deprecations` was specified in the `silence` list of `warn_error_options` on the `EventMangeer`, the `fire_event` function wasn't passing the event to the helper methods on `WarnErrorOptions`. Now the function does pass the event, and everything works.

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-common/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [X] I have run this code in development and it appears to resolve the stated issue
- [X] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [X] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-common/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
 
