### PR TITLE
Create new `WarnErrorOptionsV2` which does not inherit from `IncludeExclude`

### DIFF
--- a/.changes/unreleased/Under the Hood-20250430-122036.yaml
+++ b/.changes/unreleased/Under the Hood-20250430-122036.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Split `WarnErrorOptions` from `IncludeExclude`
+time: 2025-04-30T12:20:36.000652-05:00
+custom:
+  Author: QMalcolm
+  Issue: "278"

--- a/dbt_common/events/event_manager.py
+++ b/dbt_common/events/event_manager.py
@@ -1,11 +1,11 @@
 import os
 import traceback
-from typing import Any, List, Optional, Protocol, Tuple
+from typing import Any, List, Optional, Protocol, Tuple, Union
 
 from dbt_common.events.base_types import BaseEvent, EventLevel, msg_from_base_event, TCallback
 from dbt_common.events.logger import LoggerConfig, _Logger, _TextLogger, _JsonLogger, LineFormat
 from dbt_common.exceptions.events import EventCompilationError
-from dbt_common.helper_types import WarnErrorOptions
+from dbt_common.helper_types import WarnErrorOptions, WarnErrorOptionsV2
 
 
 class EventManager:
@@ -13,7 +13,7 @@ class EventManager:
         self.loggers: List[_Logger] = []
         self.callbacks: List[TCallback] = []
         self._warn_error: Optional[bool] = None
-        self._warn_error_options: Optional[WarnErrorOptions] = None
+        self._warn_error_options: Optional[Union[WarnErrorOptions, WarnErrorOptionsV2]] = None
         self.require_warn_or_error_handling: bool = False
 
     @property
@@ -29,15 +29,18 @@ class EventManager:
         self._warn_error = warn_error
 
     @property
-    def warn_error_options(self) -> WarnErrorOptions:
+    def warn_error_options(self) -> Union[WarnErrorOptions, WarnErrorOptionsV2]:
         if self._warn_error_options is None:
             from dbt_common.events.functions import WARN_ERROR_OPTIONS
 
-            return WARN_ERROR_OPTIONS
+            return WARN_ERROR_OPTIONS._warn_erro_options_v2
+
         return self._warn_error_options
 
     @warn_error_options.setter
-    def warn_error_options(self, warn_error_options: WarnErrorOptions) -> None:
+    def warn_error_options(
+        self, warn_error_options: Union[WarnErrorOptions, WarnErrorOptionsV2]
+    ) -> None:
         self._warn_error_options = warn_error_options
 
     def fire_event(
@@ -52,7 +55,7 @@ class EventManager:
         if force_warn_or_error_handling or (
             self.require_warn_or_error_handling and msg.info.level == "warn"
         ):
-            if self.warn_error or self.warn_error_options.includes(e):
+            if self.warn_error or self.warn_error_options.errors(e):
                 # This has the potential to create an infinite loop if the handling of the raised
                 # EventCompilationError fires an event as a warning instead of an error.
                 raise EventCompilationError(e.message(), node)
@@ -95,7 +98,7 @@ class IEventManager(Protocol):
     callbacks: List[TCallback]
     loggers: List[_Logger]
     warn_error: bool
-    warn_error_options: WarnErrorOptions
+    warn_error_options: Union[WarnErrorOptions, WarnErrorOptionsV2]
     require_warn_or_error_handling: bool
 
     def fire_event(

--- a/dbt_common/events/event_manager.py
+++ b/dbt_common/events/event_manager.py
@@ -33,7 +33,7 @@ class EventManager:
         if self._warn_error_options is None:
             from dbt_common.events.functions import WARN_ERROR_OPTIONS
 
-            return WARN_ERROR_OPTIONS._warn_erro_options_v2
+            return WARN_ERROR_OPTIONS._warn_error_options_v2
 
         return self._warn_error_options
 

--- a/dbt_common/helper_types.py
+++ b/dbt_common/helper_types.py
@@ -65,7 +65,7 @@ class IncludeExclude(dbtClassMixin):
 
 
 @dataclass
-class WarnErrorOptions(dbtClassMixin):
+class WarnErrorOptionsV2(dbtClassMixin):
     """
     This class is used to configure the behavior of the warn_error feature (now part of fire_event).
 
@@ -89,30 +89,16 @@ class WarnErrorOptions(dbtClassMixin):
 
     def __init__(
         self,
-        include: Optional[Union[str, List[str]]] = None,  # deprecated for error
-        exclude: Optional[List[str]] = None,  # deprecated for warn
-        valid_error_names: Optional[Set[str]] = None,
-        silence: Optional[List[str]] = None,
         error: Optional[Union[str, List[str]]] = None,
         warn: Optional[List[str]] = None,
+        silence: Optional[List[str]] = None,
+        valid_error_names: Optional[Set[str]] = None,
     ):
         self._valid_error_names: Set[str] = valid_error_names or set()
         self._valid_error_names.add(self.DEPRECATIONS)
 
-        if include and error:
-            raise RuntimeError(
-                "can specify either error or include, but not both, when instantiating WarnErrorOptions"
-            )
-        else:
-            self.error = error or include or []
-
-        if warn and exclude:
-            raise RuntimeError(
-                "can specify either warn or exclude, but not both, when instantiating WarnErrorOptions"
-            )
-        else:
-            self.warn = warn or exclude or []
-
+        self.error = error or []
+        self.warn = warn or []
         self.silence = silence or []
 
         # since we're overriding the dataclass auto __init__, we need to call __post_init__ manually
@@ -247,21 +233,6 @@ class WarnErrorOptions(dbtClassMixin):
             return True
         else:
             return False
-
-    @property
-    def include(self) -> Union[str, List[str]]:
-        """Deprecated, use `error` instead."""
-        return self.error
-
-    @property
-    def exclude(self) -> List[str]:
-        """Deprecated, use `warn` instead."""
-        return self.warn
-
-    @property
-    def INCLUDE_ALL(self) -> Tuple[str, str]:
-        """Deprecated, use `ERROR_ALL` instead."""
-        return self.ERROR_ALL
 
 
 FQNPath = Tuple[str, ...]

--- a/dbt_common/helper_types.py
+++ b/dbt_common/helper_types.py
@@ -64,6 +64,42 @@ class IncludeExclude(dbtClassMixin):
         pass
 
 
+class WarnErrorOptions(IncludeExclude):
+    """Deprecated, use WarnErrorOptionsV2 instead."""
+
+    DEPRECATIONS = "Deprecations"
+
+    def __init__(
+        self,
+        include: Union[str, List[str]],
+        exclude: Optional[List[str]] = None,
+        valid_error_names: Optional[Set[str]] = None,
+        silence: Optional[List[str]] = None,
+    ):
+        self.silence = silence or []
+        self._valid_error_names: Set[str] = valid_error_names or set()
+        self._valid_error_names.add(self.DEPRECATIONS)
+        super().__init__(include=include, exclude=(exclude or []))
+
+        self._warn_erro_options_v2 = WarnErrorOptionsV2(
+            error=self.include,
+            warn=self.exclude,
+            silence=self.silence,
+            valid_error_names=self._valid_error_names,
+        )
+
+    def __post_init__(self):
+        # We don't want IncludeExclude's post_init to run, so we override it.
+        # We are fine with just having the WarnErrorOptionsV2's post_init run on instantiation.
+        pass
+
+    def includes(self, item_name: Union[str, BaseEvent]) -> bool:
+        return self._warn_erro_options_v2.includes(item_name)
+
+    def silenced(self, item_name: Union[str, BaseEvent]) -> bool:
+        return self._warn_erro_options_v2.silenced(item_name)
+
+
 @dataclass
 class WarnErrorOptionsV2(dbtClassMixin):
     """

--- a/dbt_common/helper_types.py
+++ b/dbt_common/helper_types.py
@@ -96,6 +96,10 @@ class WarnErrorOptions(IncludeExclude):
     def includes(self, item_name: Union[str, BaseEvent]) -> bool:
         return self._warn_erro_options_v2.includes(item_name)
 
+    def errors(self, item_name: Union[str, BaseEvent]) -> bool:
+        """Exists for forward compatibility with WarnErrorOptionsV2."""
+        return self._warn_erro_options_v2.errors(item_name)
+
     def silenced(self, item_name: Union[str, BaseEvent]) -> bool:
         return self._warn_erro_options_v2.silenced(item_name)
 

--- a/dbt_common/helper_types.py
+++ b/dbt_common/helper_types.py
@@ -133,9 +133,11 @@ class WarnErrorOptionsV2(dbtClassMixin):
         self._valid_error_names: Set[str] = valid_error_names or set()
         self._valid_error_names.add(self.DEPRECATIONS)
 
-        self.error = error or []
-        self.warn = warn or []
-        self.silence = silence or []
+        # We can't do `= error or []` because if someone passes in an empty list, and latter appends to that list
+        # they would expect references to the original list to be updated.
+        self.error = error if error is not None else []
+        self.warn = warn if warn is not None else []
+        self.silence = silence if silence is not None else []
 
         # since we're overriding the dataclass auto __init__, we need to call __post_init__ manually
         self.__post_init__()

--- a/dbt_common/helper_types.py
+++ b/dbt_common/helper_types.py
@@ -258,6 +258,11 @@ class WarnErrorOptions(dbtClassMixin):
         """Deprecated, use `warn` instead."""
         return self.warn
 
+    @property
+    def INCLUDE_ALL(self) -> Tuple[str, str]:
+        """Deprecated, use `ERROR_ALL` instead."""
+        return self.ERROR_ALL
+
 
 FQNPath = Tuple[str, ...]
 PathSet = AbstractSet[FQNPath]

--- a/dbt_common/helper_types.py
+++ b/dbt_common/helper_types.py
@@ -81,7 +81,7 @@ class WarnErrorOptions(IncludeExclude):
         self._valid_error_names.add(self.DEPRECATIONS)
         super().__init__(include=include, exclude=(exclude or []))
 
-        self._warn_erro_options_v2 = WarnErrorOptionsV2(
+        self._warn_error_options_v2 = WarnErrorOptionsV2(
             error=self.include,
             warn=self.exclude,
             silence=self.silence,
@@ -94,14 +94,14 @@ class WarnErrorOptions(IncludeExclude):
         pass
 
     def includes(self, item_name: Union[str, BaseEvent]) -> bool:
-        return self._warn_erro_options_v2.includes(item_name)
+        return self._warn_error_options_v2.includes(item_name)
 
     def errors(self, item_name: Union[str, BaseEvent]) -> bool:
         """Exists for forward compatibility with WarnErrorOptionsV2."""
-        return self._warn_erro_options_v2.errors(item_name)
+        return self._warn_error_options_v2.errors(item_name)
 
     def silenced(self, item_name: Union[str, BaseEvent]) -> bool:
-        return self._warn_erro_options_v2.silenced(item_name)
+        return self._warn_error_options_v2.silenced(item_name)
 
 
 @dataclass

--- a/tests/unit/test_event_manager.py
+++ b/tests/unit/test_event_manager.py
@@ -1,5 +1,6 @@
 from dbt_common.events.event_manager import EventManager
 from dbt_common.events.types import BehaviorChangeEvent
+from dbt_common.helper_types import WarnErrorOptionsV2
 from tests.unit.utils import EventCatcher
 
 
@@ -10,6 +11,10 @@ class TestEventManager:
 
         event_manager.add_callback(EventCatcher().catch)
         assert len(event_manager.callbacks) == 1
+
+    def test_default_warn_error_options(self) -> None:
+        event_manager = EventManager()
+        assert event_manager.warn_error_options.to_dict() == WarnErrorOptionsV2().to_dict()
 
 
 class TestEventManagerSilencedDeprecation:

--- a/tests/unit/test_functions.py
+++ b/tests/unit/test_functions.py
@@ -76,7 +76,7 @@ class TestFireEvent:
 class TestDeprecatedWarnOrError:
     def test_fires_error(self, valid_error_names: Set[str]) -> None:
         get_event_manager().warn_error_options = WarnErrorOptions(
-            include="*", valid_error_names=valid_error_names
+            error="*", valid_error_names=valid_error_names
         )
         with pytest.raises(EventCompilationError):
             functions.warn_or_error(Note(msg="hi"))
@@ -88,7 +88,7 @@ class TestDeprecatedWarnOrError:
         set_event_manager_with_catcher: None,
     ) -> None:
         get_event_manager().warn_error_options = WarnErrorOptions(
-            include="*", exclude=list(valid_error_names), valid_error_names=valid_error_names
+            error="*", warn=list(valid_error_names), valid_error_names=valid_error_names
         )
         functions.warn_or_error(Note(msg="hi"))
         assert len(event_catcher.caught_events) == 1
@@ -101,7 +101,7 @@ class TestDeprecatedWarnOrError:
         set_event_manager_with_catcher: None,
     ) -> None:
         get_event_manager().warn_error_options = WarnErrorOptions(
-            include="*", silence=list(valid_error_names), valid_error_names=valid_error_names
+            error="*", silence=list(valid_error_names), valid_error_names=valid_error_names
         )
         functions.warn_or_error(Note(msg="hi"))
         assert len(event_catcher.caught_events) == 0

--- a/tests/unit/test_functions.py
+++ b/tests/unit/test_functions.py
@@ -76,7 +76,7 @@ class TestFireEvent:
 class TestDeprecatedWarnOrError:
     def test_fires_error(self, valid_error_names: Set[str]) -> None:
         get_event_manager().warn_error_options = WarnErrorOptions(
-            error="*", valid_error_names=valid_error_names
+            include="*", valid_error_names=valid_error_names
         )
         with pytest.raises(EventCompilationError):
             functions.warn_or_error(Note(msg="hi"))
@@ -88,7 +88,7 @@ class TestDeprecatedWarnOrError:
         set_event_manager_with_catcher: None,
     ) -> None:
         get_event_manager().warn_error_options = WarnErrorOptions(
-            error="*", warn=list(valid_error_names), valid_error_names=valid_error_names
+            include="*", exclude=list(valid_error_names), valid_error_names=valid_error_names
         )
         functions.warn_or_error(Note(msg="hi"))
         assert len(event_catcher.caught_events) == 1
@@ -101,7 +101,7 @@ class TestDeprecatedWarnOrError:
         set_event_manager_with_catcher: None,
     ) -> None:
         get_event_manager().warn_error_options = WarnErrorOptions(
-            error="*", silence=list(valid_error_names), valid_error_names=valid_error_names
+            include="*", silence=list(valid_error_names), valid_error_names=valid_error_names
         )
         functions.warn_or_error(Note(msg="hi"))
         assert len(event_catcher.caught_events) == 0

--- a/tests/unit/test_helper_types.py
+++ b/tests/unit/test_helper_types.py
@@ -149,16 +149,3 @@ class TestWarnErrorOptions:
             valid_error_names={"BehaviorChangeEvent", "ItemB"},
         )
         assert my_options.silenced(BehaviorChangeEvent()) == expected_silence
-
-    def test_deprecated_functionality(self) -> None:
-        errors = "all"
-        warn = ["ItemB"]
-        my_options = WarnErrorOptions(
-            include=errors, exclude=warn, valid_error_names={"BehaviorChangeEvent", "ItemB"}
-        )
-
-        assert my_options.error == errors
-        assert my_options.include == errors  # deprecated but accessible
-        assert my_options.warn == warn
-        assert my_options.exclude == warn  # deprecated but accessible
-        assert my_options.includes("BehaviorChangeEvent")  # deprecated but accessible

--- a/tests/unit/test_helper_types.py
+++ b/tests/unit/test_helper_types.py
@@ -162,3 +162,18 @@ class TestWarnErrorOptions:
         assert my_options.warn == warn
         assert my_options.exclude == warn  # deprecated but accessible
         assert my_options.includes("BehaviorChangeEvent")  # deprecated but accessible
+
+    def test_serialization(self) -> None:
+        my_options = WarnErrorOptions(
+            include="*",
+            exclude=["ItemB"],
+            silence=["BehaviorChangeEvent"],
+            valid_error_names={"BehaviorChangeEvent", "ItemB"},
+        )
+
+        dictified = my_options.to_dict()
+        assert "error" in dictified
+        assert "warn" in dictified
+        assert "silence" in dictified
+        assert "include" not in dictified
+        assert "exclude" not in dictified

--- a/tests/unit/test_helper_types.py
+++ b/tests/unit/test_helper_types.py
@@ -35,51 +35,51 @@ class TestIncludeExclude:
 class TestWarnErrorOptions:
     def test_init_invalid_error(self) -> None:
         with pytest.raises(ValidationError):
-            WarnErrorOptions(error=["InvalidError"], valid_error_names=set(["ValidError"]))
+            WarnErrorOptions(include=["InvalidError"], valid_error_names=set(["ValidError"]))
 
         with pytest.raises(ValidationError):
             WarnErrorOptions(
-                error="*", warn=["InvalidError"], valid_error_names=set(["ValidError"])
+                include="*", exclude=["InvalidError"], valid_error_names=set(["ValidError"])
             )
 
     def test_init_invalid_error_default_valid_error_names(self) -> None:
         with pytest.raises(ValidationError):
-            WarnErrorOptions(error=["InvalidError"])
+            WarnErrorOptions(include=["InvalidError"])
 
         with pytest.raises(ValidationError):
-            WarnErrorOptions(error="*", warn=["InvalidError"])
+            WarnErrorOptions(include="*", exclude=["InvalidError"])
 
     def test_init_valid_error(self) -> None:
         warn_error_options = WarnErrorOptions(
-            error=["ValidError"], valid_error_names=set(["ValidError"])
+            include=["ValidError"], valid_error_names=set(["ValidError"])
         )
-        assert warn_error_options.error == ["ValidError"]
-        assert warn_error_options.warn == []
+        assert warn_error_options.include == ["ValidError"]
+        assert warn_error_options.exclude == []
 
         warn_error_options = WarnErrorOptions(
-            error="*", warn=["ValidError"], valid_error_names=set(["ValidError"])
+            include="*", exclude=["ValidError"], valid_error_names=set(["ValidError"])
         )
-        assert warn_error_options.error == "*"
-        assert warn_error_options.warn == ["ValidError"]
+        assert warn_error_options.include == "*"
+        assert warn_error_options.exclude == ["ValidError"]
 
     def test_init_default_silence(self) -> None:
-        my_options = WarnErrorOptions(error="*")
+        my_options = WarnErrorOptions(include="*")
         assert my_options.silence == []
 
     def test_init_invalid_silence_event(self) -> None:
         with pytest.raises(ValidationError):
-            WarnErrorOptions(error="*", silence=["InvalidError"])
+            WarnErrorOptions(include="*", silence=["InvalidError"])
 
     def test_init_valid_silence_event(self) -> None:
         all_events = ["MySilencedEvent"]
         my_options = WarnErrorOptions(
-            error="*", silence=all_events, valid_error_names=set(all_events)
+            include="*", silence=all_events, valid_error_names=set(all_events)
         )
         assert my_options.silence == all_events
 
     # NOTE: BehaviorChangeEvent is a deprecation event
     @pytest.mark.parametrize(
-        "error,warn,silence,expected_errors",
+        "include,exclude,silence,expected_includes",
         [
             ([], [], [], False),
             (["BehaviorChangeEvent"], [], ["BehaviorChangeEvent"], False),
@@ -99,25 +99,25 @@ class TestWarnErrorOptions:
             (["Deprecations"], ["Deprecations"], ["Deprecations"], False),
         ],
     )
-    def test_errors(
+    def test_includes(
         self,
-        error: Union[str, List[str]],
-        warn: List[str],
+        include: Union[str, List[str]],
+        exclude: List[str],
         silence: List[str],
-        expected_errors: bool,
+        expected_includes: bool,
     ) -> None:
-        error_warn = WarnErrorOptions(
-            error=error,
-            warn=warn,
+        include_exclude = WarnErrorOptions(
+            include=include,
+            exclude=exclude,
             silence=silence,
             valid_error_names={"BehaviorChangeEvent", "ItemB"},
         )
 
-        assert error_warn.errors(BehaviorChangeEvent()) == expected_errors
+        assert include_exclude.includes(BehaviorChangeEvent()) == expected_includes
 
     # NOTE: BehaviorChangeEvent is a deprecation event
     @pytest.mark.parametrize(
-        "error,warn,silence,expected_silence",
+        "include,exclude,silence,expected_silence",
         [
             (["BehaviorChangeEvent"], [], ["BehaviorChangeEvent"], True),
             ("all", ["BehaviorChangeEvent"], ["BehaviorChangeEvent"], True),
@@ -137,14 +137,14 @@ class TestWarnErrorOptions:
     )
     def test_silenced(
         self,
-        error: Union[str, List[str]],
-        warn: List[str],
+        include: Union[str, List[str]],
+        exclude: List[str],
         silence: List[str],
         expected_silence: bool,
     ) -> None:
         my_options = WarnErrorOptions(
-            error=error,
-            warn=warn,
+            include=include,
+            exclude=exclude,
             silence=silence,
             valid_error_names={"BehaviorChangeEvent", "ItemB"},
         )

--- a/tests/unit/test_helper_types.py
+++ b/tests/unit/test_helper_types.py
@@ -149,3 +149,16 @@ class TestWarnErrorOptions:
             valid_error_names={"BehaviorChangeEvent", "ItemB"},
         )
         assert my_options.silenced(BehaviorChangeEvent()) == expected_silence
+
+    def test_deprecated_functionality(self) -> None:
+        errors = "all"
+        warn = ["ItemB"]
+        my_options = WarnErrorOptions(
+            include=errors, exclude=warn, valid_error_names={"BehaviorChangeEvent", "ItemB"}
+        )
+
+        assert my_options.error == errors
+        assert my_options.include == errors  # deprecated but accessible
+        assert my_options.warn == warn
+        assert my_options.exclude == warn  # deprecated but accessible
+        assert my_options.includes("BehaviorChangeEvent")  # deprecated but accessible

--- a/tests/unit/test_helper_types.py
+++ b/tests/unit/test_helper_types.py
@@ -162,18 +162,3 @@ class TestWarnErrorOptions:
         assert my_options.warn == warn
         assert my_options.exclude == warn  # deprecated but accessible
         assert my_options.includes("BehaviorChangeEvent")  # deprecated but accessible
-
-    def test_serialization(self) -> None:
-        my_options = WarnErrorOptions(
-            include="*",
-            exclude=["ItemB"],
-            silence=["BehaviorChangeEvent"],
-            valid_error_names={"BehaviorChangeEvent", "ItemB"},
-        )
-
-        dictified = my_options.to_dict()
-        assert "error" in dictified
-        assert "warn" in dictified
-        assert "silence" in dictified
-        assert "include" not in dictified
-        assert "exclude" not in dictified

--- a/tests/unit/test_helper_types.py
+++ b/tests/unit/test_helper_types.py
@@ -35,51 +35,51 @@ class TestIncludeExclude:
 class TestWarnErrorOptions:
     def test_init_invalid_error(self) -> None:
         with pytest.raises(ValidationError):
-            WarnErrorOptions(include=["InvalidError"], valid_error_names=set(["ValidError"]))
+            WarnErrorOptions(error=["InvalidError"], valid_error_names=set(["ValidError"]))
 
         with pytest.raises(ValidationError):
             WarnErrorOptions(
-                include="*", exclude=["InvalidError"], valid_error_names=set(["ValidError"])
+                error="*", warn=["InvalidError"], valid_error_names=set(["ValidError"])
             )
 
     def test_init_invalid_error_default_valid_error_names(self) -> None:
         with pytest.raises(ValidationError):
-            WarnErrorOptions(include=["InvalidError"])
+            WarnErrorOptions(error=["InvalidError"])
 
         with pytest.raises(ValidationError):
-            WarnErrorOptions(include="*", exclude=["InvalidError"])
+            WarnErrorOptions(error="*", warn=["InvalidError"])
 
     def test_init_valid_error(self) -> None:
         warn_error_options = WarnErrorOptions(
-            include=["ValidError"], valid_error_names=set(["ValidError"])
+            error=["ValidError"], valid_error_names=set(["ValidError"])
         )
-        assert warn_error_options.include == ["ValidError"]
-        assert warn_error_options.exclude == []
+        assert warn_error_options.error == ["ValidError"]
+        assert warn_error_options.warn == []
 
         warn_error_options = WarnErrorOptions(
-            include="*", exclude=["ValidError"], valid_error_names=set(["ValidError"])
+            error="*", warn=["ValidError"], valid_error_names=set(["ValidError"])
         )
-        assert warn_error_options.include == "*"
-        assert warn_error_options.exclude == ["ValidError"]
+        assert warn_error_options.error == "*"
+        assert warn_error_options.warn == ["ValidError"]
 
     def test_init_default_silence(self) -> None:
-        my_options = WarnErrorOptions(include="*")
+        my_options = WarnErrorOptions(error="*")
         assert my_options.silence == []
 
     def test_init_invalid_silence_event(self) -> None:
         with pytest.raises(ValidationError):
-            WarnErrorOptions(include="*", silence=["InvalidError"])
+            WarnErrorOptions(error="*", silence=["InvalidError"])
 
     def test_init_valid_silence_event(self) -> None:
         all_events = ["MySilencedEvent"]
         my_options = WarnErrorOptions(
-            include="*", silence=all_events, valid_error_names=set(all_events)
+            error="*", silence=all_events, valid_error_names=set(all_events)
         )
         assert my_options.silence == all_events
 
     # NOTE: BehaviorChangeEvent is a deprecation event
     @pytest.mark.parametrize(
-        "include,exclude,silence,expected_includes",
+        "error,warn,silence,expected_errors",
         [
             ([], [], [], False),
             (["BehaviorChangeEvent"], [], ["BehaviorChangeEvent"], False),
@@ -99,25 +99,25 @@ class TestWarnErrorOptions:
             (["Deprecations"], ["Deprecations"], ["Deprecations"], False),
         ],
     )
-    def test_includes(
+    def test_errors(
         self,
-        include: Union[str, List[str]],
-        exclude: List[str],
+        error: Union[str, List[str]],
+        warn: List[str],
         silence: List[str],
-        expected_includes: bool,
+        expected_errors: bool,
     ) -> None:
-        include_exclude = WarnErrorOptions(
-            include=include,
-            exclude=exclude,
+        error_warn = WarnErrorOptions(
+            error=error,
+            warn=warn,
             silence=silence,
             valid_error_names={"BehaviorChangeEvent", "ItemB"},
         )
 
-        assert include_exclude.includes(BehaviorChangeEvent()) == expected_includes
+        assert error_warn.errors(BehaviorChangeEvent()) == expected_errors
 
     # NOTE: BehaviorChangeEvent is a deprecation event
     @pytest.mark.parametrize(
-        "include,exclude,silence,expected_silence",
+        "error,warn,silence,expected_silence",
         [
             (["BehaviorChangeEvent"], [], ["BehaviorChangeEvent"], True),
             ("all", ["BehaviorChangeEvent"], ["BehaviorChangeEvent"], True),
@@ -137,14 +137,14 @@ class TestWarnErrorOptions:
     )
     def test_silenced(
         self,
-        include: Union[str, List[str]],
-        exclude: List[str],
+        error: Union[str, List[str]],
+        warn: List[str],
         silence: List[str],
         expected_silence: bool,
     ) -> None:
         my_options = WarnErrorOptions(
-            include=include,
-            exclude=exclude,
+            error=error,
+            warn=warn,
             silence=silence,
             valid_error_names={"BehaviorChangeEvent", "ItemB"},
         )

--- a/tests/unit/test_helper_types.py
+++ b/tests/unit/test_helper_types.py
@@ -150,6 +150,10 @@ class TestWarnErrorOptions:
         )
         assert my_options.silenced(BehaviorChangeEvent()) == expected_silence
 
+    def test_dictification(self) -> None:
+        my_options = WarnErrorOptions(include=[], exclude=[])
+        assert my_options.to_dict() == {"include": [], "exclude": []}
+
 
 class TestWarnErrorOptionsV2:
     def test_init_invalid_error(self) -> None:
@@ -268,3 +272,7 @@ class TestWarnErrorOptionsV2:
             valid_error_names={"BehaviorChangeEvent", "ItemB"},
         )
         assert my_options.silenced(BehaviorChangeEvent()) == expected_silence
+
+    def test_dictification(self) -> None:
+        my_options = WarnErrorOptionsV2(error=[], warn=[], silence=[])
+        assert my_options.to_dict() == {"error": [], "warn": [], "silence": []}

--- a/tests/unit/test_helper_types.py
+++ b/tests/unit/test_helper_types.py
@@ -2,7 +2,7 @@ from dbt_common.events.types import BehaviorChangeEvent
 import pytest
 from typing import List, Union
 
-from dbt_common.helper_types import IncludeExclude, WarnErrorOptions
+from dbt_common.helper_types import IncludeExclude, WarnErrorOptions, WarnErrorOptionsV2
 from dbt_common.dataclass_schema import ValidationError
 
 
@@ -145,6 +145,125 @@ class TestWarnErrorOptions:
         my_options = WarnErrorOptions(
             include=include,
             exclude=exclude,
+            silence=silence,
+            valid_error_names={"BehaviorChangeEvent", "ItemB"},
+        )
+        assert my_options.silenced(BehaviorChangeEvent()) == expected_silence
+
+
+class TestWarnErrorOptionsV2:
+    def test_init_invalid_error(self) -> None:
+        with pytest.raises(ValidationError):
+            WarnErrorOptionsV2(error=["InvalidError"], valid_error_names=set(["ValidError"]))
+
+        with pytest.raises(ValidationError):
+            WarnErrorOptionsV2(
+                error="*", warn=["InvalidError"], valid_error_names=set(["ValidError"])
+            )
+
+    def test_init_invalid_error_default_valid_error_names(self) -> None:
+        with pytest.raises(ValidationError):
+            WarnErrorOptionsV2(error=["InvalidError"])
+
+        with pytest.raises(ValidationError):
+            WarnErrorOptionsV2(error="*", warn=["InvalidError"])
+
+    def test_init_valid_error(self) -> None:
+        warn_error_options = WarnErrorOptionsV2(
+            error=["ValidError"], valid_error_names=set(["ValidError"])
+        )
+        assert warn_error_options.error == ["ValidError"]
+        assert warn_error_options.warn == []
+
+        warn_error_options = WarnErrorOptionsV2(
+            error="*", warn=["ValidError"], valid_error_names=set(["ValidError"])
+        )
+        assert warn_error_options.error == "*"
+        assert warn_error_options.warn == ["ValidError"]
+
+    def test_init_default_silence(self) -> None:
+        my_options = WarnErrorOptionsV2(error="*")
+        assert my_options.silence == []
+
+    def test_init_invalid_silence_event(self) -> None:
+        with pytest.raises(ValidationError):
+            WarnErrorOptionsV2(error="*", silence=["InvalidError"])
+
+    def test_init_valid_silence_event(self) -> None:
+        all_events = ["MySilencedEvent"]
+        my_options = WarnErrorOptionsV2(
+            error="*", silence=all_events, valid_error_names=set(all_events)
+        )
+        assert my_options.silence == all_events
+
+    # NOTE: BehaviorChangeEvent is a deprecation event
+    @pytest.mark.parametrize(
+        "error,warn,silence,expected_errors",
+        [
+            ([], [], [], False),
+            (["BehaviorChangeEvent"], [], ["BehaviorChangeEvent"], False),
+            (["BehaviorChangeEvent"], [], [], True),
+            ("*", ["BehaviorChangeEvent"], ["BehaviorChangeEvent"], False),
+            ("*", [], ["BehaviorChangeEvent"], False),
+            ("*", ["BehaviorChangeEvent"], [], False),
+            ("*", [], [], True),
+            ("*", ["ItemB"], [], True),
+            ("*", [], ["ItemB"], True),
+            (["BehaviorChangeEvent"], [], ["Deprecations"], True),
+            (["Deprecations"], [], ["BehaviorChangeEvent"], False),
+            (["Deprecations"], ["BehaviorChangeEvent"], [], False),
+            (["Deprecations"], [], [], True),
+            ("*", ["Deprecations"], [], False),
+            ("*", [], ["Deprecations"], False),
+            (["Deprecations"], ["Deprecations"], ["Deprecations"], False),
+        ],
+    )
+    def test_errors(
+        self,
+        error: Union[str, List[str]],
+        warn: List[str],
+        silence: List[str],
+        expected_errors: bool,
+    ) -> None:
+        error_warn = WarnErrorOptionsV2(
+            error=error,
+            warn=warn,
+            silence=silence,
+            valid_error_names={"BehaviorChangeEvent", "ItemB"},
+        )
+
+        assert error_warn.errors(BehaviorChangeEvent()) == expected_errors
+
+    # NOTE: BehaviorChangeEvent is a deprecation event
+    @pytest.mark.parametrize(
+        "error,warn,silence,expected_silence",
+        [
+            (["BehaviorChangeEvent"], [], ["BehaviorChangeEvent"], True),
+            ("all", ["BehaviorChangeEvent"], ["BehaviorChangeEvent"], True),
+            ([], [], ["BehaviorChangeEvent"], True),
+            ("*", [], ["BehaviorChangeEvent"], True),
+            (["BehaviorChangeEvent"], [], [], False),
+            ("*", [], [], False),
+            ("*", ["BehaviorChangeEvent"], [], False),
+            ([], [], [], False),
+            (["BehaviorChangeEvent"], [], ["Deprecations"], False),
+            ([], ["BehaviorChangeEvent"], ["Deprecations"], False),
+            (["Deprecations"], [], ["BehaviorChangeEvent"], True),
+            ([], [], ["Deprecations"], True),
+            ("*", [], ["Deprecations"], True),
+            (["Deprecations"], ["Deprecations"], ["Deprecations"], True),
+        ],
+    )
+    def test_silenced(
+        self,
+        error: Union[str, List[str]],
+        warn: List[str],
+        silence: List[str],
+        expected_silence: bool,
+    ) -> None:
+        my_options = WarnErrorOptionsV2(
+            error=error,
+            warn=warn,
             silence=silence,
             valid_error_names={"BehaviorChangeEvent", "ItemB"},
         )


### PR DESCRIPTION
resolves #278

### Description

Over time `WarnErrorOptions` has diverged more and more heavily from `IncludeExclude`. We haven't had a need to split them until now though. Core issue https://github.com/dbt-labs/dbt-core/issues/11557 aims to deprecate the `include`/`exclude` terminology from uses of `WarnErrorOptions`. To do so though, it requires that `WarnErrorOptions` uses `error`/`warn` under the hood. To make that possible, it also makes sense to break the inheritance. Unfortunately, due to this line of [core](https://github.com/dbt-labs/dbt-core/blob/3c95db9c0028d03d20074c4428f1e63df9823dbd/core/dbt/task/retry.py#L96), we can't _directly_ break the inheritance. So instead I've create a new class `WarnErrorOptionsV2` which dances around the problem in order to maintain backwards compatibility 

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-common/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [X] I have run this code in development and it appears to resolve the stated issue
- [X] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [X] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-common/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
 
