### PR TITLE
Optionally put event name in message tags

### DIFF
--- a/.changes/unreleased/Features-20250508-165056.yaml
+++ b/.changes/unreleased/Features-20250508-165056.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Optionally allow event name in event tags
+time: 2025-05-08T16:50:56.138247-05:00
+custom:
+  Author: QMalcolm
+  Issue: "281"

--- a/dbt_common/ui.py
+++ b/dbt_common/ui.py
@@ -79,10 +79,10 @@ def line_wrap_message(msg: str, subtract: int = 0, dedent: bool = True, prefix: 
 
 
 def warning_tag(msg: str, event_name: Optional[str] = None) -> str:
+    tag = f'[{yellow("WARNING")}]'
     if event_name:
-        return f'[{yellow("WARNING")}][{event_name}]: {msg}'
-    else:
-        return f'[{yellow("WARNING")}]: {msg}'
+        tag += f"[{event_name}]"
+    return f"{tag}: {msg}"
 
 
 def deprecation_tag(msg: str, event_name: Optional[str] = None) -> str:
@@ -90,7 +90,7 @@ def deprecation_tag(msg: str, event_name: Optional[str] = None) -> str:
 
 
 def error_tag(msg: str, event_name: Optional[str] = None) -> str:
+    tag = f'[{red("ERROR")}]'
     if event_name:
-        return f'[{red("ERROR")}][{event_name}]: {msg}'
-    else:
-        return f'[{red("ERROR")}]: {msg}'
+        tag += f"[{event_name}]"
+    return f"{tag}: {msg}"

--- a/dbt_common/ui.py
+++ b/dbt_common/ui.py
@@ -1,7 +1,7 @@
 from os import getenv as os_getenv
 import sys
 import textwrap
-from typing import Dict
+from typing import Dict, Optional
 
 import colorama
 
@@ -78,13 +78,19 @@ def line_wrap_message(msg: str, subtract: int = 0, dedent: bool = True, prefix: 
     return "\n".join(textwrap.fill(chunk, width=width, break_on_hyphens=False) for chunk in chunks)
 
 
-def warning_tag(msg: str) -> str:
-    return f'[{yellow("WARNING")}]: {msg}'
+def warning_tag(msg: str, event_name: Optional[str] = None) -> str:
+    if event_name:
+        return f'[{yellow("WARNING")}][{event_name}]: {msg}'
+    else:
+        return f'[{yellow("WARNING")}]: {msg}'
 
 
-def deprecation_tag(msg: str) -> str:
-    return warning_tag(f"Deprecated functionality\n\n{msg}")
+def deprecation_tag(msg: str, event_name: Optional[str] = None) -> str:
+    return warning_tag(f"Deprecated functionality\n\n{msg}", event_name)
 
 
-def error_tag(msg: str) -> str:
-    return f'[{red("ERROR")}]: {msg}'
+def error_tag(msg: str, event_name: Optional[str] = None) -> str:
+    if event_name:
+        return f'[{red("ERROR")}][{event_name}]: {msg}'
+    else:
+        return f'[{red("ERROR")}]: {msg}'

--- a/tests/unit/test_ui.py
+++ b/tests/unit/test_ui.py
@@ -1,11 +1,25 @@
-from dbt_common.ui import warning_tag, error_tag
+from dbt_common.ui import deprecation_tag, warning_tag, error_tag
 
 
 def test_warning_tag() -> None:
     tagged = warning_tag("hi")
-    assert "WARNING" in tagged
+    assert tagged == "[\x1b[33mWARNING\x1b[0m]: hi"
+
+    tagged = warning_tag("hi", "MyWarningEvent")
+    assert tagged == "[\x1b[33mWARNING\x1b[0m][MyWarningEvent]: hi"
 
 
 def test_error_tag() -> None:
     tagged = error_tag("hi")
-    assert "ERROR" in tagged
+    assert tagged == "[\x1b[31mERROR\x1b[0m]: hi"
+
+    tagged = error_tag("hi", "MyErrorEvent")
+    assert tagged == "[\x1b[31mERROR\x1b[0m][MyErrorEvent]: hi"
+
+
+def test_deprecation_tag() -> None:
+    tagged = deprecation_tag("hi")
+    assert tagged == "[\x1b[33mWARNING\x1b[0m]: Deprecated functionality\n\nhi"
+
+    tagged = deprecation_tag("hi", "MyDeprecationEvent")
+    assert tagged == "[\x1b[33mWARNING\x1b[0m][MyDeprecationEvent]: Deprecated functionality\n\nhi"

--- a/tests/unit/test_ui.py
+++ b/tests/unit/test_ui.py
@@ -3,23 +3,34 @@ from dbt_common.ui import deprecation_tag, warning_tag, error_tag
 
 def test_warning_tag() -> None:
     tagged = warning_tag("hi")
-    assert tagged == "[\x1b[33mWARNING\x1b[0m]: hi"
+    assert "WARNING" in tagged
+    assert "hi" in tagged
 
     tagged = warning_tag("hi", "MyWarningEvent")
-    assert tagged == "[\x1b[33mWARNING\x1b[0m][MyWarningEvent]: hi"
+    assert "WARNING" in tagged
+    assert "[MyWarningEvent]:" in tagged
+    assert "hi" in tagged
 
 
 def test_error_tag() -> None:
     tagged = error_tag("hi")
-    assert tagged == "[\x1b[31mERROR\x1b[0m]: hi"
+    assert "ERROR" in tagged
+    assert "hi" in tagged
 
     tagged = error_tag("hi", "MyErrorEvent")
-    assert tagged == "[\x1b[31mERROR\x1b[0m][MyErrorEvent]: hi"
+    assert "ERROR" in tagged
+    assert "[MyErrorEvent]:" in tagged
+    assert "hi" in tagged
 
 
 def test_deprecation_tag() -> None:
     tagged = deprecation_tag("hi")
-    assert tagged == "[\x1b[33mWARNING\x1b[0m]: Deprecated functionality\n\nhi"
+    assert "WARNING" in tagged
+    assert "Deprecated functionality" in tagged
+    assert "hi" in tagged
 
     tagged = deprecation_tag("hi", "MyDeprecationEvent")
-    assert tagged == "[\x1b[33mWARNING\x1b[0m][MyDeprecationEvent]: Deprecated functionality\n\nhi"
+    assert "WARNING" in tagged
+    assert "[MyDeprecationEvent]:" in tagged
+    assert "Deprecated functionality" in tagged
+    assert "hi" in tagged


### PR DESCRIPTION
resolves #281


### Description

Sometimes it's nice to know what an event is. Especially since we now have a [deprecations doc page](https://docs.getdbt.com/reference/deprecations), which has the event name 

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-common/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [X] I have run this code in development and it appears to resolve the stated issue
- [X] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [X] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-common/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
 
