### PR TITLE
Capturing BadGzipFile exception in connection_exception_retry

### DIFF
--- a/.changes/unreleased/Fixes-20250530-151648.yaml
+++ b/.changes/unreleased/Fixes-20250530-151648.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Capturing BadGzipFile exception in connection_exception_retry
+time: 2025-05-30T15:16:48.995145-07:00
+custom:
+    Author: leaomatheus
+    Issue: "290"

--- a/dbt_common/utils/connection.py
+++ b/dbt_common/utils/connection.py
@@ -4,6 +4,7 @@ from typing import Callable
 from dbt_common.events.types import RecordRetryException, RetryExternalCall
 from dbt_common.exceptions import ConnectionError
 from tarfile import ReadError
+from gzip import BadGzipFile
 
 import requests
 
@@ -23,6 +24,7 @@ def connection_exception_retry(fn: Callable, max_attempts: int, attempt: int = 0
         requests.exceptions.RequestException,
         ReadError,
         EOFError,
+        BadGzipFile,
     ) as exc:
         if attempt <= max_attempts - 1:
             # This import needs to be inline to avoid circular dependency

--- a/tests/unit/test_core_dbt_utils.py
+++ b/tests/unit/test_core_dbt_utils.py
@@ -1,3 +1,4 @@
+import gzip
 import requests
 import tarfile
 import unittest
@@ -31,6 +32,11 @@ class TestCommonDbtUtils(unittest.TestCase):
     def test_connection_exception_retry_success_failed_eofexception(self) -> None:
         Counter._reset()
         connection_exception_retry(lambda: Counter._add_with_eof_exception(), 5)
+        self.assertEqual(2, counter)  # 2 = original attempt returned EOFError, plus 1 retry
+
+    def test_connection_exception_retry_success_failed_badgzipfileexception(self) -> None:
+        Counter._reset()
+        connection_exception_retry(lambda: Counter._add_with_bad_gzip_file_exception(), 5)
         self.assertEqual(2, counter)  # 2 = original attempt returned EOFError, plus 1 retry
 
 
@@ -72,6 +78,13 @@ class Counter:
         counter += 1
         if counter < 2:
             raise EOFError
+
+    @classmethod
+    def _add_with_bad_gzip_file_exception(cls) -> None:
+        global counter
+        counter += 1
+        if counter < 2:
+            raise gzip.BadGzipFile
 
     @classmethod
     def _reset(cls) -> None:


### PR DESCRIPTION
resolves #290

Issue described in https://github.com/dbt-labs/dbt-common/issues/290

### Description

This is a transient failure that can be resolved by capturing the right exception.

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-common/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [X] I have run this code in development and it appears to resolve the stated issue
- [X] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [X] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-common/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
 
