### PR TITLE
Begin tracking add adapter types to invocation context

### DIFF
--- a/.changes/unreleased/Features-20250710-134758.yaml
+++ b/.changes/unreleased/Features-20250710-134758.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Begin tracking adapters in invocation context
+time: 2025-07-10T13:47:58.998587-05:00
+custom:
+  Author: QMalcolm
+  Issue: "292"

--- a/dbt_common/context.py
+++ b/dbt_common/context.py
@@ -1,6 +1,6 @@
 import os
 from contextvars import ContextVar, copy_context
-from typing import List, Mapping, Optional, Iterator
+from typing import List, Mapping, Optional, Iterator, Set
 
 from dbt_common.constants import PRIVATE_ENV_PREFIX, SECRET_ENV_PREFIX
 from dbt_common.record import Recorder
@@ -43,7 +43,7 @@ class InvocationContext:
         self._env_secrets: Optional[List[str]] = None
         self._env_private = env_private
         self.recorder: Optional[Recorder] = None
-        self._adapter_type: Optional[str] = None
+        self._adapter_types: Set[str] = set()
 
         # If set to True later, this flag will prevent dbt from creating a new
         # invocation context for every invocation, which is useful for testing
@@ -69,12 +69,15 @@ class InvocationContext:
         return self._env_secrets
 
     @property
-    def adapter_type(self) -> Optional[str]:
-        return self._adapter_type
+    def adapter_types(self) -> Set[str]:
+        return self._adapter_types
 
-    @adapter_type.setter
-    def adapter_type(self, adapter_type: str) -> None:
-        self._adapter_type = adapter_type
+    @adapter_types.setter
+    def adapter_types(self, adapters: Set[str]) -> None:
+        self._adapter_types = adapters
+
+    def uses_adapter(self, adapter_type: str) -> None:
+        self._adapter_types.add(adapter_type)
 
 
 _INVOCATION_CONTEXT_VAR: ContextVar[InvocationContext] = ContextVar("DBT_INVOCATION_CONTEXT_VAR")

--- a/dbt_common/context.py
+++ b/dbt_common/context.py
@@ -43,6 +43,7 @@ class InvocationContext:
         self._env_secrets: Optional[List[str]] = None
         self._env_private = env_private
         self.recorder: Optional[Recorder] = None
+        self._adapter_type: Optional[str] = None
 
         # If set to True later, this flag will prevent dbt from creating a new
         # invocation context for every invocation, which is useful for testing
@@ -66,6 +67,14 @@ class InvocationContext:
                 v for k, v in self.env.items() if k.startswith(SECRET_ENV_PREFIX) and v.strip()
             ]
         return self._env_secrets
+
+    @property
+    def adapter_type(self) -> Optional[str]:
+        return self._adapter_type
+
+    @adapter_type.setter
+    def adapter_type(self, adapter_type: str) -> None:
+        self._adapter_type = adapter_type
 
 
 _INVOCATION_CONTEXT_VAR: ContextVar[InvocationContext] = ContextVar("DBT_INVOCATION_CONTEXT_VAR")


### PR DESCRIPTION
resolves #292 

### Description

We want to keep track of the adapter types being used in an invocation. This is necessary for https://github.com/dbt-labs/dbt-core/pull/11828

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-common/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [X] I have run this code in development and it appears to resolve the stated issue
- [X] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [X] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-common/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
 
