### PR TITLE
use D000 for BehaviorChangeEvent

### DIFF
--- a/dbt_common/events/types.py
+++ b/dbt_common/events/types.py
@@ -38,7 +38,7 @@ from dbt_common.ui import warning_tag
 
 class BehaviorChangeEvent(WarnLevel):
     def code(self) -> str:
-        return "D018"
+        return "D000"
 
     def message(self) -> str:
         return warning_tag(


### PR DESCRIPTION
resolves #N/A

Updating BehaviorChangeEvent.code to D000 to avoid duplication across dbt-core/dbt-common

Confirmed no usage of D000 in dbt-core: https://github.com/dbt-labs/dbt-core/blob/1fcce443ba82ba6bd897f6135ae6bfda9d2367d/core/dbt/events/types.py#L550
