### PR TITLE
fix system.rename deleted source folder before rename causing a FileN…

### DIFF
--- a/dbt_common/clients/system.py
+++ b/dbt_common/clients/system.py
@@ -600,6 +600,9 @@ def rename(from_path: str, to_path: str, force: bool = False) -> None:
     to_path = convert_path(to_path)
     is_symlink = path_is_symlink(to_path)
 
+    if from_path == to_path:
+        return
+
     if os.path.exists(to_path) and force:
         if is_symlink:
             remove_file(to_path)


### PR DESCRIPTION
…otFOundException https://github.com/dbt-labs/dbt-common/issues/307

resolves #307 
and https://github.com/dbt-labs/dbt-core/issues/11035

### Description

Add a simple equality check and no-op if the source and target paths for `system.rename` are equal and `force == true`

Not sure if there are any other considerations here that need to be made?

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-common/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-common/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
 
