### PR TITLE
lock recording file during streamed recording writes

### DIFF
--- a/.changes/unreleased/Under the Hood-20250910-140011.yaml
+++ b/.changes/unreleased/Under the Hood-20250910-140011.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Lock recordings.json during streamed recording
+time: 2025-09-10T14:00:11.747166-04:00
+custom:
+    Author: michelleark
+    Issue: "312"

--- a/dbt_common/record.py
+++ b/dbt_common/record.py
@@ -201,7 +201,7 @@ class Recorder:
             self._counter += 1
 
         if self._recording_file is not None:
-            # Lock file during streamed recording to avoid race conditions across recording threads
+            # Lock recording file during streamed recording to avoid race conditions across recording threads
             with self._recording_file_lock:
                 if self._record_added:
                     self._recording_file.write(",")
@@ -211,7 +211,8 @@ class Recorder:
                     self._record_added = True
                 except Exception:
                     json.dump(
-                        {"type": "RecordingError", "record_type": rec_cls_name}, self._recording_file
+                        {"type": "RecordingError", "record_type": rec_cls_name},
+                        self._recording_file,
                     )
         else:
             if rec_cls_name not in self._records_by_type:

--- a/dbt_common/record.py
+++ b/dbt_common/record.py
@@ -179,6 +179,7 @@ class Recorder:
 
         self._record_added = False
         self._recording_file: Optional[TextIO] = None
+        self._recording_file_lock = Lock()
         if mode == RecorderMode.RECORD and not in_memory:
             self._recording_file = open(current_recording_path, "w")
             self._recording_file.write("[")
@@ -200,16 +201,18 @@ class Recorder:
             self._counter += 1
 
         if self._recording_file is not None:
-            if self._record_added:
-                self._recording_file.write(",")
-            try:
-                dct = Recorder._get_tagged_dict(record, rec_cls_name)
-                json.dump(dct, self._recording_file)
-                self._record_added = True
-            except Exception:
-                json.dump(
-                    {"type": "RecordingError", "record_type": rec_cls_name}, self._recording_file
-                )
+            # Lock file during streamed recording to avoid race conditions across recording threads
+            with self._recording_file_lock:
+                if self._record_added:
+                    self._recording_file.write(",")
+                try:
+                    dct = Recorder._get_tagged_dict(record, rec_cls_name)
+                    json.dump(dct, self._recording_file)
+                    self._record_added = True
+                except Exception:
+                    json.dump(
+                        {"type": "RecordingError", "record_type": rec_cls_name}, self._recording_file
+                    )
         else:
             if rec_cls_name not in self._records_by_type:
                 self._records_by_type[rec_cls_name] = []


### PR DESCRIPTION
resolves https://github.com/dbt-labs/dbt-common/issues/312

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->

### Description

<!---
  Describe the Pull Request here. Add any references and info to help reviewers
  understand your changes. Include any tradeoffs you considered.
-->
Adding a lock around streamed writes of recordings.json. Given the existing `_counter_lock` at a very similar section of the method, feel this is very low-risk both in terms of performance or introduction of deadlock scenarios. 

Was tested running a 1hr (single-threaded) job across 16 threads on an internal project and confirmed no significant performance degradation + a well-formed recordings.json was produced.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-common/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-common/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
 
