### PR TITLE
Safer Param class instantiation for auto-recorded methods with overrides

### DIFF
--- a/.changes/unreleased/Under the Hood-20250916-165201.yaml
+++ b/.changes/unreleased/Under the Hood-20250916-165201.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Safer Param class instantiation for auto-recorded methods with overrides
+time: 2025-09-16T16:52:01.866622-04:00
+custom:
+    Author: michelleark
+    Issue: "313"

--- a/dbt_common/record.py
+++ b/dbt_common/record.py
@@ -535,17 +535,25 @@ def _record_function_inner(
             else:
                 param_args = (getattr(args[0], id_field_name),) + param_args
 
-        # Omits any additional properties that are not fields of the params class
-        params_dict = {
-            field.name: value
-            for field, value in zip(dataclasses.fields(record_type.params_cls), param_args)
-        }
-        params_dict.update(kwargs)
-        params = (
-            record_type.params_cls._from_dict(params_dict)
-            if hasattr(record_type.params_cls, "_from_dict")
-            else record_type.params_cls(*param_args, **kwargs)
-        )
+        # Build params - this can be dangerous if a subclass overrides the method in such a way that
+        # changes the signature of the base recorded method, and so is wrapped in a try/except.
+        params = None
+        try:
+            # Omits any additional properties that are not fields of the params class
+            params_dict = {
+                field.name: value
+                for field, value in zip(dataclasses.fields(record_type.params_cls), param_args)
+            }
+            params_dict.update(kwargs)
+            params = (
+                record_type.params_cls._from_dict(params_dict)
+                if hasattr(record_type.params_cls, "_from_dict")
+                else record_type.params_cls(*param_args, **kwargs)
+            )
+        except Exception:
+            # Unfortunately it is not possible to fire an event here because it would cause a circular import
+            # This means we lose visibility into the issue, but it is better than crashing the entire node or command
+            pass
 
         include = True
         if hasattr(params, "_include"):
@@ -554,7 +562,7 @@ def _record_function_inner(
         if not include:
             return func_to_record(*call_args, **kwargs)
 
-        if recorder.mode == RecorderMode.REPLAY:
+        if recorder.mode == RecorderMode.REPLAY and params is not None:
             return recorder.expect_record(params)
         if RECORDED_BY_HIGHER_FUNCTION.get():
             return func_to_record(*call_args, **kwargs)
@@ -569,7 +577,8 @@ def _record_function_inner(
             else record_type.result_cls(r)
         )
         RECORDED_BY_HIGHER_FUNCTION.set(False)
-        recorder.add_record(record_type(params=params, result=result))
+        if params is not None:
+            recorder.add_record(record_type(params=params, result=result))
         return r
 
     setattr(

--- a/dbt_common/record.py
+++ b/dbt_common/record.py
@@ -545,11 +545,14 @@ def _record_function_inner(
                 for field, value in zip(dataclasses.fields(record_type.params_cls), param_args)
             }
             params_dict.update(kwargs)
-            params = (
-                record_type.params_cls._from_dict(params_dict)
-                if hasattr(record_type.params_cls, "_from_dict")
-                else record_type.params_cls(*param_args, **kwargs)
-            )
+            try:
+                params = record_type.params_cls._from_dict(params_dict)
+            except (TypeError, AttributeError):
+                params = record_type.params_cls(*param_args, **kwargs)
+            except Exception:
+                # Unfortunately it is not possible to fire an event here because it would cause a circular import
+                # This means we lose visibility into the issue, but it is better than crashing the entire node or command
+                pass
         except Exception:
             # Unfortunately it is not possible to fire an event here because it would cause a circular import
             # This means we lose visibility into the issue, but it is better than crashing the entire node or command

--- a/dbt_common/record.py
+++ b/dbt_common/record.py
@@ -556,7 +556,7 @@ def _record_function_inner(
             pass
 
         include = True
-        if hasattr(params, "_include"):
+        if params is not None and hasattr(params, "_include"):
             include = params._include()
 
         if not include:

--- a/recording.json
+++ b/recording.json
@@ -1,1 +1,0 @@
-[{"params": {"thread_id": "unset"}, "result": {"return_val": 42}, "seq": 0, "type": "TestAutoRecord"}]

--- a/recording.json
+++ b/recording.json
@@ -1,0 +1,1 @@
+[{"params": {"thread_id": "unset"}, "result": {"return_val": 42}, "seq": 0, "type": "TestAutoRecord"}]

--- a/tests/unit/test_record.py
+++ b/tests/unit/test_record.py
@@ -289,6 +289,35 @@ def test_recorded_function_with_override() -> None:
     assert recorder._records_by_type["TestAutoRecord"][-1].result.return_val == 4
 
 
+def test_recorded_function_with_override_and_additional_properties() -> None:
+    os.environ["DBT_RECORDER_MODE"] = "Record"
+    recorder = Recorder(RecorderMode.RECORD, None, in_memory=True)
+    set_invocation_context({})
+    get_invocation_context().recorder = recorder
+
+    @supports_replay
+    class Recordable:
+        @auto_record_function("TestAuto")
+        def test_func(self, a: int) -> int:
+            return 2 * a
+
+    class RecordableSubclass(Recordable):
+        def test_func(self, a: int) -> int:
+            return 3 * a
+
+    class RecordableSubSubclass(RecordableSubclass):
+        def test_func(self, a: int, b: int) -> int:
+            return (4 * a) + b
+
+    rs = RecordableSubSubclass()
+
+    rs.test_func(1, 2)
+
+    assert recorder._records_by_type["TestAutoRecord"][-1].params.a == 1
+    assert not hasattr(recorder._records_by_type["TestAutoRecord"][-1].params, "b")
+    assert recorder._records_by_type["TestAutoRecord"][-1].result.return_val == 6
+
+
 class CustomType:
     def __init__(self, n: int):
         self.value = n

--- a/tests/unit/test_record.py
+++ b/tests/unit/test_record.py
@@ -375,8 +375,9 @@ def test_recorded_function_with_override_and_removed_fields() -> None:
     rs = RecordableSubSubclass()
 
     # This should not raise an exception, even though a recording could not be added
-    rs.test_func()
+    result = rs.test_func()
 
+    assert result == 1
     assert "TestAutoRecord" not in recorder._records_by_type.keys()
 
 

--- a/tests/unit/test_record.py
+++ b/tests/unit/test_record.py
@@ -374,8 +374,10 @@ def test_recorded_function_with_override_and_removed_fields() -> None:
 
     rs = RecordableSubSubclass()
 
+    # This should not raise an exception, even though a recording could not be added
     rs.test_func()
 
+    assert "TestAutoRecord" not in recorder._records_by_type.keys()
 
 class CustomType:
     def __init__(self, n: int):

--- a/tests/unit/test_record.py
+++ b/tests/unit/test_record.py
@@ -306,7 +306,7 @@ def test_recorded_function_with_override_and_additional_properties() -> None:
             return 3 * a
 
     class RecordableSubSubclass(RecordableSubclass):
-        def test_func(self, a: int, b: int) -> int:
+        def test_func(self, a: int, b: int) -> int:  # type: ignore
             return (4 * a) + b
 
     rs = RecordableSubSubclass()

--- a/tests/unit/test_record.py
+++ b/tests/unit/test_record.py
@@ -379,6 +379,7 @@ def test_recorded_function_with_override_and_removed_fields() -> None:
 
     assert "TestAutoRecord" not in recorder._records_by_type.keys()
 
+
 class CustomType:
     def __init__(self, n: int):
         self.value = n


### PR DESCRIPTION
<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->

### Description

<!---
  Describe the Pull Request here. Add any references and info to help reviewers
  understand your changes. Include any tradeoffs you considered.
-->

* Uses _from_dict directly to build param dataclass, in order to actively omit any unexpected fields from the caller
* Wraps param building behind coarse try/except clause as recordings should fail as gracefully as possible and creating parameters can be risky depending on subclass overrides

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-common/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-common/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
 
Additional testing against dbt-core: https://github.com/dbt-labs/dbt-core/pull/12020 (all tests running with record-mode on)
* 🍏 https://github.com/dbt-labs/dbt-core/actions/runs/17801821491/job/50603411247?pr=12020