### PR TITLE
Improve `EventCatcher` and beging distributing it as part of the package

### DIFF
--- a/.changes/unreleased/Features-20251027-133357.yaml
+++ b/.changes/unreleased/Features-20251027-133357.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Begin distributing the `EventCatcher` testing utility
+time: 2025-10-27T13:33:57.65258-05:00
+custom:
+  Author: QMalcolm
+  Issue: N/A

--- a/dbt_common/events/base_types.py
+++ b/dbt_common/events/base_types.py
@@ -1,7 +1,7 @@
 import os
 import threading
 from enum import Enum
-from typing import Callable, Optional, Protocol
+from typing import Callable, Optional, Protocol, TypeVar
 
 from dbt_common.events import types_pb2
 from google.protobuf.json_format import MessageToDict, MessageToJson, ParseDict
@@ -111,6 +111,9 @@ class BaseEvent:
 
     def code(self) -> str:
         raise Exception("code() not implemented for event")
+
+
+EventType = TypeVar("EventType", bound=BaseEvent)
 
 
 class EventInfo(Protocol):

--- a/dbt_common/events/event_catcher.py
+++ b/dbt_common/events/event_catcher.py
@@ -1,12 +1,21 @@
 from dataclasses import dataclass, field
-from typing import List
+from typing import Callable, List, Optional
 
-from dbt_common.events.base_types import EventMsg
+from dbt_common.events.base_types import BaseEvent, EventMsg
 
 
 @dataclass
 class EventCatcher:
+    event_to_catch: Optional[BaseEvent] = None
     caught_events: List[EventMsg] = field(default_factory=list)
+    predicate: Callable[[EventMsg], bool] = lambda event: True
 
-    def catch(self, event: EventMsg) -> None:
-        self.caught_events.append(event)
+    def _check_event_type(self, event: EventMsg) -> bool:
+        return self.event_to_catch is None or event.info.name == self.event_to_catch.__name__
+
+    def catch(self, event: EventMsg):
+        if self._check_event_type(event) and self.predicate(event):
+            self.caught_events.append(event)
+
+    def flush(self) -> None:
+        self.caught_events = []

--- a/dbt_common/events/event_catcher.py
+++ b/dbt_common/events/event_catcher.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass, field
+from typing import List
+
+from dbt_common.events.base_types import EventMsg
+
+
+@dataclass
+class EventCatcher:
+    caught_events: List[EventMsg] = field(default_factory=list)
+
+    def catch(self, event: EventMsg) -> None:
+        self.caught_events.append(event)

--- a/dbt_common/events/event_catcher.py
+++ b/dbt_common/events/event_catcher.py
@@ -1,12 +1,12 @@
 from dataclasses import dataclass, field
 from typing import Callable, List, Optional
 
-from dbt_common.events.base_types import BaseEvent, EventMsg
+from dbt_common.events.base_types import EventMsg, EventType
 
 
 @dataclass
 class EventCatcher:
-    event_to_catch: Optional[BaseEvent] = None
+    event_to_catch: Optional[EventType] = None
     caught_events: List[EventMsg] = field(default_factory=list)
     predicate: Callable[[EventMsg], bool] = lambda event: True
 

--- a/tests/unit/test_behavior_flags.py
+++ b/tests/unit/test_behavior_flags.py
@@ -1,8 +1,8 @@
 import pytest
 
 from dbt_common.behavior_flags import Behavior
+from dbt_common.events.event_catcher import EventCatcher
 from dbt_common.exceptions.base import CompilationError, DbtInternalError
-from tests.unit.utils import EventCatcher
 
 
 def test_behavior_default() -> None:

--- a/tests/unit/test_event_catcher.py
+++ b/tests/unit/test_event_catcher.py
@@ -1,0 +1,63 @@
+from dbt_common.events.event_catcher import EventCatcher
+from dbt_common.events.event_manager import EventManager
+from dbt_common.events.types import Formatting, Note
+
+
+class TestEventCatcher:
+    def test_basic_catcher(self) -> None:
+        # Setup
+        event_manager = EventManager()
+        event_catcher = EventCatcher()
+        event_manager.add_callback(event_catcher.catch)
+
+        # Fire events
+        event_manager.fire_event(Note(msg="test"))
+
+        # Validate
+        assert len(event_catcher.caught_events) == 1
+
+    def test_catching_specific_event(self) -> None:
+        # Setup
+        event_manager = EventManager()
+        note_catcher = EventCatcher(event_to_catch=Note)
+        event_manager.add_callback(note_catcher.catch)
+
+        # Fire events
+        event_manager.fire_event(Formatting(msg="woof"))
+        event_manager.fire_event(Note(msg="meow"))
+
+        # Validate
+        assert len(note_catcher.caught_events) == 1
+        assert note_catcher.caught_events[0].data.msg == "meow"
+
+    def test_catching_specific_event_with_predicate(self) -> None:
+        # Setup
+        event_manager = EventManager()
+        predicate_catcher = EventCatcher(predicate=lambda event: event.data.msg == "woof")
+        event_manager.add_callback(predicate_catcher.catch)
+
+        # Fire events
+        event_manager.fire_event(Formatting(msg="woof"))
+        event_manager.fire_event(Note(msg="meow"))
+
+        # Validate
+        assert len(predicate_catcher.caught_events) == 1
+        assert predicate_catcher.caught_events[0].data.msg == "woof"
+
+    def test_catching_specific_event_with_predicate_and_event_to_catch(self) -> None:
+        # Setup
+        event_manager = EventManager()
+        note_catcher = EventCatcher(
+            event_to_catch=Note, predicate=lambda event: event.data.msg == "neigh"
+        )
+        event_manager.add_callback(note_catcher.catch)
+
+        # Fire events
+        event_manager.fire_event(Note(msg="woof"))
+        event_manager.fire_event(Note(msg="neigh"))
+        event_manager.fire_event(Note(msg="meow"))
+        event_manager.fire_event(Formatting(msg="neigh"))
+
+        # Validate
+        assert len(note_catcher.caught_events) == 1
+        assert note_catcher.caught_events[0].data.msg == "neigh"

--- a/tests/unit/test_event_manager.py
+++ b/tests/unit/test_event_manager.py
@@ -1,7 +1,7 @@
+from dbt_common.events.event_catcher import EventCatcher
 from dbt_common.events.event_manager import EventManager
 from dbt_common.events.types import BehaviorChangeEvent
 from dbt_common.helper_types import WarnErrorOptionsV2
-from tests.unit.utils import EventCatcher
 
 
 class TestEventManager:

--- a/tests/unit/test_event_manager_client.py
+++ b/tests/unit/test_event_manager_client.py
@@ -1,8 +1,8 @@
 from pytest_mock import MockerFixture
 
+from dbt_common.events.event_catcher import EventCatcher
 from dbt_common.events.event_manager import EventManager
 from dbt_common.events.event_manager_client import add_callback_to_manager, get_event_manager
-from tests.unit.utils import EventCatcher
 
 
 def test_add_callback_to_manager(mocker: MockerFixture) -> None:

--- a/tests/unit/test_functions.py
+++ b/tests/unit/test_functions.py
@@ -2,11 +2,11 @@ import pytest
 
 from dbt_common.events import functions
 from dbt_common.events.base_types import EventLevel, WarnLevel
+from dbt_common.events.event_catcher import EventCatcher
 from dbt_common.events.event_manager import EventManager
 from dbt_common.events.event_manager_client import ctx_set_event_manager, get_event_manager
 from dbt_common.exceptions import EventCompilationError
 from dbt_common.helper_types import WarnErrorOptions
-from tests.unit.utils import EventCatcher
 from typing import Set
 
 

--- a/tests/unit/utils.py
+++ b/tests/unit/utils.py
@@ -1,20 +1,9 @@
-from dataclasses import dataclass, field
-from typing import List
-
 import pytest
 from pytest_mock import MockerFixture
 
-from dbt_common.events.base_types import EventMsg
+from dbt_common.events.event_catcher import EventCatcher
 from dbt_common.events.event_manager import EventManager
 from dbt_common.events.event_manager_client import add_callback_to_manager
-
-
-@dataclass
-class EventCatcher:
-    caught_events: List[EventMsg] = field(default_factory=list)
-
-    def catch(self, event: EventMsg) -> None:
-        self.caught_events.append(event)
 
 
 @pytest.fixture(scope="function")


### PR DESCRIPTION
resolves #NA

### Description

I was doing work in dbt-adapters and came to the realization that to do my testing I needed the `EventCatcher` class. I could have added one to dbt-adapters, but that'd be actually kind of smelly at this point. See we've had an `EventCatcher` in dbt-common, and another `EventCatcher` in dbt-core. However, both of these only existed in the `tests` lib of both packages (not distributed). Additionally, the dbt-core `EventCatcher` had added functionality that the dbt-common implementation never did. This PR:

1. Begins distributing the `EventCatcher` as part of the dbt-common package
2. Updates the `EventCatcher` to have the improvements previously made to the dbt-core `EventCatcher`
3. Fixes a longstanding typing issue with the `EventCatcher`

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-common/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [X] I have run this code in development and it appears to resolve the stated issue
- [X] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [X] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-common/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
 
