### PR TITLE
Stringify `3.10` in pre_release.yml workflow

### DIFF
--- a/.github/workflows/pre_release.yml
+++ b/.github/workflows/pre_release.yml
@@ -44,7 +44,7 @@ defaults:
     shell: bash
 
 env:
-  PYTHON_TARGET_VERSION: 3.10
+  PYTHON_TARGET_VERSION: "3.10"
   NOTIFICATION_PREFIX: "[Release Preparation]"
 
 jobs:


### PR DESCRIPTION
resolves #N/A


### Description

We were specifying the python version in the `pre_release.yml` as
```
  PYTHON_TARGET_VERSION: 3.10
```
The `3.10` part of that was being interpreted as a float, and getting truncated to `3.1`. We need to stringify the version so it doesn't get truncated 🤦🏻 

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-common/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [X] I have run this code in development and it appears to resolve the stated issue
- [X] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [X] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-common/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
 
