### PR TITLE
add row limit to recorder

### DIFF
--- a/.changes/unreleased/Under the Hood-20251105-154808.yaml
+++ b/.changes/unreleased/Under the Hood-20251105-154808.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Add record_row_limit to Recorder
+time: 2025-11-05T15:48:08.26621-05:00
+custom:
+    Author: michelleark
+    Issue: "323"

--- a/.changes/unreleased/Under the Hood-20251105-154808.yaml
+++ b/.changes/unreleased/Under the Hood-20251105-154808.yaml
@@ -1,5 +1,5 @@
 kind: Under the Hood
-body: Add record_row_limit to Recorder
+body: Add record_row_limit to Recorder, and support DBT_ENGINE prefix for record/replay environment variables
 time: 2025-11-05T15:48:08.26621-05:00
 custom:
     Author: michelleark

--- a/dbt_common/record.py
+++ b/dbt_common/record.py
@@ -341,7 +341,9 @@ def get_record_mode_from_env() -> Optional[RecorderMode]:
     if record_mode is None:
         return None
 
-    record_file_path = os.environ.get("DBT_ENGINE_RECORDER_FILE_PATH") or os.environ.get("DBT_RECORDER_FILE_PATH")
+    record_file_path = os.environ.get("DBT_ENGINE_RECORDER_FILE_PATH") or os.environ.get(
+        "DBT_RECORDER_FILE_PATH"
+    )
     if record_mode.lower() == "record":
         return RecorderMode.RECORD
     # diffing requires a file path, otherwise treat as noop
@@ -363,7 +365,9 @@ def get_record_types_from_env() -> Optional[List]:
     Invalid types will be ignored.
     Expected format: 'DBT_RECORDER_TYPES=Database,FileLoadRecord' or 'DBT_ENGINE_RECORDER_TYPES=Database,FileLoadRecord'
     """
-    record_types_str = os.environ.get("DBT_ENGINE_RECORDER_TYPES") or os.environ.get("DBT_RECORDER_TYPES")
+    record_types_str = os.environ.get("DBT_ENGINE_RECORDER_TYPES") or os.environ.get(
+        "DBT_RECORDER_TYPES"
+    )
 
     # if all is specified we don't want any type filtering
     if record_types_str is None or record_types_str.lower == "all":
@@ -376,7 +380,9 @@ def get_record_row_limit_from_env() -> Optional[int]:
     """
     Get the record row limit from the environment variables.
     """
-    record_row_limit_str = os.environ.get("DBT_ENGINE_RECORDER_ROW_LIMIT") or os.environ.get("DBT_RECORDER_ROW_LIMIT")
+    record_row_limit_str = os.environ.get("DBT_ENGINE_RECORDER_ROW_LIMIT") or os.environ.get(
+        "DBT_RECORDER_ROW_LIMIT"
+    )
     if record_row_limit_str is None:
         return None
 

--- a/dbt_common/record.py
+++ b/dbt_common/record.py
@@ -194,7 +194,7 @@ class Recorder:
         cls._record_cls_by_name[rec_type.__name__] = rec_type
         cls._record_name_by_params_name[rec_type.params_cls.__name__] = rec_type.__name__
         return rec_type
-    
+
     @property
     def record_row_limit(self) -> Optional[int]:
         return self._record_row_limit

--- a/dbt_common/record.py
+++ b/dbt_common/record.py
@@ -149,12 +149,14 @@ class Recorder:
         self,
         mode: RecorderMode,
         types: Optional[List],
+        row_limit: Optional[int] = None,
         current_recording_path: str = "recording.json",
         previous_recording_path: Optional[str] = None,
         in_memory: bool = False,
     ) -> None:
         self.mode = mode
         self.recorded_types = types
+        self._record_row_limit: Optional[int] = get_record_row_limit_from_env()
         self._records_by_type: Dict[str, List[Record]] = {}
         self._unprocessed_records_by_type: Dict[str, List[Dict[str, Any]]] = {}
         self._replay_diffs: List["Diff"] = []
@@ -192,6 +194,10 @@ class Recorder:
         cls._record_cls_by_name[rec_type.__name__] = rec_type
         cls._record_name_by_params_name[rec_type.params_cls.__name__] = rec_type.__name__
         return rec_type
+    
+    @property
+    def record_row_limit(self) -> Optional[int]:
+        return self._record_row_limit
 
     def add_record(self, record: Record) -> None:
         rec_cls_name = record.__class__.__name__  # type: ignore
@@ -361,6 +367,17 @@ def get_record_types_from_env() -> Optional[List]:
         return None
 
     return record_types_str.split(",")
+
+
+def get_record_row_limit_from_env() -> Optional[int]:
+    """
+    Get the record row limit from the environment variables.
+    """
+    record_row_limit_str = os.environ.get("DBT_RECORDER_ROW_LIMIT")
+    if record_row_limit_str is None:
+        return None
+
+    return int(record_row_limit_str)
 
 
 def get_record_types_from_dict(fp: str) -> List:

--- a/dbt_common/record.py
+++ b/dbt_common/record.py
@@ -99,7 +99,9 @@ class Diff:
 
         exclude_paths = [
             "root[0]['result']['env']['DBT_RECORDER_FILE_PATH']",
+            "root[0]['result']['env']['DBT_ENGINE_RECORDER_FILE_PATH']",
             "root[0]['result']['env']['DBT_RECORDER_MODE']",
+            "root[0]['result']['env']['DBT_ENGINE_RECORDER_MODE']",
         ]
 
         return self.diff(
@@ -332,20 +334,21 @@ def get_record_mode_from_env() -> Optional[RecorderMode]:
     Get the record mode from the environment variables.
 
     If the mode is not set to 'RECORD', 'DIFF' or 'REPLAY', return None.
-    Expected format: 'DBT_RECORDER_MODE=RECORD'
+    Expected format: 'DBT_RECORDER_MODE=RECORD' or 'DBT_ENGINE_RECORDER_MODE=RECORD'
     """
-    record_mode = os.environ.get("DBT_RECORDER_MODE")
+    record_mode = os.environ.get("DBT_ENGINE_RECORDER_MODE") or os.environ.get("DBT_RECORDER_MODE")
 
     if record_mode is None:
         return None
 
+    record_file_path = os.environ.get("DBT_ENGINE_RECORDER_FILE_PATH") or os.environ.get("DBT_RECORDER_FILE_PATH")
     if record_mode.lower() == "record":
         return RecorderMode.RECORD
     # diffing requires a file path, otherwise treat as noop
-    elif record_mode.lower() == "diff" and os.environ.get("DBT_RECORDER_FILE_PATH") is not None:
+    elif record_mode.lower() == "diff" and record_file_path is not None:
         return RecorderMode.DIFF
     # replaying requires a file path, otherwise treat as noop
-    elif record_mode.lower() == "replay" and os.environ.get("DBT_RECORDER_FILE_PATH") is not None:
+    elif record_mode.lower() == "replay" and record_file_path is not None:
         return RecorderMode.REPLAY
 
     # if you don't specify record/replay it's a noop
@@ -358,9 +361,9 @@ def get_record_types_from_env() -> Optional[List]:
 
     If no types are provided, there will be no filtering.
     Invalid types will be ignored.
-    Expected format: 'DBT_RECORDER_TYPES=Database,FileLoadRecord'
+    Expected format: 'DBT_RECORDER_TYPES=Database,FileLoadRecord' or 'DBT_ENGINE_RECORDER_TYPES=Database,FileLoadRecord'
     """
-    record_types_str = os.environ.get("DBT_RECORDER_TYPES")
+    record_types_str = os.environ.get("DBT_ENGINE_RECORDER_TYPES") or os.environ.get("DBT_RECORDER_TYPES")
 
     # if all is specified we don't want any type filtering
     if record_types_str is None or record_types_str.lower == "all":
@@ -373,7 +376,7 @@ def get_record_row_limit_from_env() -> Optional[int]:
     """
     Get the record row limit from the environment variables.
     """
-    record_row_limit_str = os.environ.get("DBT_RECORDER_ROW_LIMIT")
+    record_row_limit_str = os.environ.get("DBT_ENGINE_RECORDER_ROW_LIMIT") or os.environ.get("DBT_RECORDER_ROW_LIMIT")
     if record_row_limit_str is None:
         return None
 

--- a/docs/guides/record_replay.md
+++ b/docs/guides/record_replay.md
@@ -32,23 +32,23 @@ With these decorators applied and classes defined, dbt is able to record all fil
 
 ## How to record/replay
 
-Record/replay behavior is activated and configured via environment variables. When DBT_RECORDER_MODE is unset, the entire subsystem is disabled, and the decorators described above have no effect at all. This helps isolate the subsystem from core's application code, reducing the risk of performance impact or regressions.
+Record/replay behavior is activated and configured via environment variables. When DBT_ENGINE_RECORDER_MODE is unset, the entire subsystem is disabled, and the decorators described above have no effect at all. This helps isolate the subsystem from core's application code, reducing the risk of performance impact or regressions.
 
-The record/replay subsystem is activated by setting the `DBT_RECORDER_MODE` variable to `replay`, `record`, or `diff`, case insensitive.  Invalid values are ignored and do not throw exceptions.
+The record/replay subsystem is activated by setting the `DBT_ENGINE_RECORDER_MODE` variable to `replay`, `record`, or `diff`, case insensitive.  Invalid values are ignored and do not throw exceptions.
 
-`DBT_RECORDER_TYPES` is optional.  It indicates which types to filter the results by and expects a list of strings values for the `Record` subclasses or groups of such classes. For example, all records of database/DWH interaction performed by adapters belong to the `Database` group. Any invalid type or group name will be ignored.  `all` is a valid value for this variable and has the same effect as not populating the variable.
+`DBT_ENGINE_RECORDER_TYPES` is optional.  It indicates which types to filter the results by and expects a list of strings values for the `Record` subclasses or groups of such classes. For example, all records of database/DWH interaction performed by adapters belong to the `Database` group. Any invalid type or group name will be ignored.  `all` is a valid value for this variable and has the same effect as not populating the variable.
 
 
 ```bash
-DBT_RECORDER_MODE=record DBT_RECORDER_TYPES=Database dbt run
+DBT_ENGINE_RECORDER_MODE=record DBT_ENGINE_RECORDER_TYPES=Database dbt run
 ```
 
 replay need the file to replay
 ```bash
-DBT_RECORDER_MODE=replay DBT_RECORDER_FILE_PATH=recording.json dbt run
+DBT_ENGINE_RECORDER_MODE=replay DBT_ENGINE_RECORDER_FILE_PATH=recording.json dbt run
 ```
 
-`DBT_RECORDER_ROW_LIMIT` is optional. When specified as an integer, it indicates the limit on how many rows of unbounded record structures (e.g. `agate.Table` results) when `DBT_RECORDER_MODE=record`. By default, no limit is set. This configuration should be leveraged when looking to optimize memory pressure that `DBT_RECORDER_MODE=record` may introduce when serializing large objects during execution.
+`DBT_ENGINE_RECORDER_ROW_LIMIT` is optional. When specified as an integer, it indicates the limit on how many rows of unbounded record structures (e.g. `agate.Table` results) when `DBT_ENGINE_RECORDER_MODE=record`. By default, no limit is set. This configuration should be leveraged when looking to optimize memory pressure that `DBT_ENGINE_RECORDER_MODE=record` may introduce when serializing large objects during execution.
 
 ## Final Thoughts
   

--- a/docs/guides/record_replay.md
+++ b/docs/guides/record_replay.md
@@ -48,6 +48,8 @@ replay need the file to replay
 DBT_RECORDER_MODE=replay DBT_RECORDER_FILE_PATH=recording.json dbt run
 ```
 
+`DBT_RECORDER_ROW_LIMIT` is optional. When specified as an integer, it indicates the limit on how many rows of unbounded record structures (e.g. `agate.Table` results) when `DBT_RECORDER_MODE=record`. By default, no limit is set. This configuration should be leveraged when looking to optimize memory pressure that `DBT_RECORDER_MODE=record` may introduce when serializing large objects during execution.
+
 ## Final Thoughts
   
 We are aware of the potential limitations of this mechanism, since it makes several strong assumptions, not least of which are:


### PR DESCRIPTION
Currently, there is no limit on the size of data that is serialized during recording when `DBT_RECORDER_MODE='record'`. This could potentially lead to memory issues when large responses (e.g. agate.Table) are serialized as part of recording.
 
This PR introduces a env-var configurable row limit that record instances (e.g. declared in dbt-adapters) can make use of when defining serializers.