### PR TITLE
update core testing to use new setup_db.sh path

### DIFF
--- a/.github/workflows/ci_dbt_core_testing.yml
+++ b/.github/workflows/ci_dbt_core_testing.yml
@@ -238,7 +238,7 @@ jobs:
 
       - name: Run postgres setup script
         run: |
-          ./test/setup_db.sh
+          ./scripts/setup_db.sh
         env:
           PGHOST: localhost
           PGPORT: 5432
@@ -300,7 +300,7 @@ jobs:
         with:
           timeout_minutes: 10
           max_attempts: 3
-          command: ./test/setup_db.sh
+          command: ./scripts/setup_db.sh
 
       - name: "Set up postgres (windows)"
         if: runner.os == 'Windows'


### PR DESCRIPTION
follow up to: https://github.com/dbt-labs/dbt-core/pull/12273

example failures: https://github.com/dbt-labs/dbt-common/actions/runs/20143082939