### PR TITLE
Add optional header support to seed helper function

### DIFF
--- a/.changes/unreleased/Features-20260104-231744.yaml
+++ b/.changes/unreleased/Features-20260104-231744.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Add seed header option support
+time: 2026-01-04T23:17:44.313671+01:00
+custom:
+    Author: aammett
+    Issue: "341"

--- a/dbt_common/clients/agate_helper.py
+++ b/dbt_common/clients/agate_helper.py
@@ -149,12 +149,24 @@ def as_matrix(table):
     return [r.values() for r in table.rows.values()]
 
 
-def from_csv(abspath, text_columns, delimiter=",") -> agate.Table:
+def from_csv(
+    abspath: str,
+    text_columns: dict,
+    delimiter: str = ",",
+    column_names: Optional[List[str]] = None,
+    header: bool = True,
+) -> agate.Table:
     type_tester = build_type_tester(text_columns=text_columns)
     with open(abspath, encoding="utf-8") as fp:
         if fp.read(1) != BOM:
             fp.seek(0)
-        return agate.Table.from_csv(fp, column_types=type_tester, delimiter=delimiter)
+        return agate.Table.from_csv(
+            fp,
+            column_types=type_tester,
+            delimiter=delimiter,
+            column_names=column_names,
+            header=header,
+        )
 
 
 class _NullMarker:


### PR DESCRIPTION
resolves 
https://github.com/dbt-labs/dbt-common/issues/341
https://github.com/dbt-labs/dbt-core/issues/11334

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->

### Description


If I've configured my seed's column names in a yml file, I don't want to also keep a header row up-to-date in my csv seed file.

```
seeds:
  - name: my_seed
    columns:
      - name: country_code
        data_type: varchar(2)
      - name: country_name
        data_type: varchar(32)
```
```
country_code,country_name
US,United States
CA,Canada
GB,United Kingdom
```
Instead, I should be able to configure my seed to not need a header row if I've configured my column names in yml already.

```
seeds:
  - name: my_seed
    config:
      header: false
    columns:
      - name: country_code
        data_type: varchar(2)
      - name: country_name
        data_type: varchar(32)

```
```
US,United States
CA,Canada
GB,United Kingdom
```

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-common/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-common/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)