### PR TITLE
Overriding branches to test to ensure only main branch gets tested

### DIFF
--- a/.github/workflows/scheduled_testing.yml
+++ b/.github/workflows/scheduled_testing.yml
@@ -25,9 +25,8 @@ permissions: read-all
 
 jobs:
   run_tests:
-    uses: dbt-labs/actions/.github/workflows/release-branch-tests.yml@fix/non-release-override
+    uses: dbt-labs/actions/.github/workflows/release-branch-tests.yml@main
     with:
       workflows_to_run: '["ci_tests.yml", "build.yml", "ci_dbt_core_testing.yml"]'
       branch_override: '["main"]'
-      dry_run: true # This is only to test if the release-branch-tests.yml workflow is working as expected. This should be reverted before merging.
     secrets: inherit

--- a/.github/workflows/scheduled_testing.yml
+++ b/.github/workflows/scheduled_testing.yml
@@ -25,7 +25,9 @@ permissions: read-all
 
 jobs:
   run_tests:
-    uses: dbt-labs/actions/.github/workflows/release-branch-tests.yml@main
+    uses: dbt-labs/actions/.github/workflows/release-branch-tests.yml@fix/non-release-override
     with:
       workflows_to_run: '["ci_tests.yml", "build.yml", "ci_dbt_core_testing.yml"]'
+      branch_override: '["main"]'
+      dry_run: true # This is only to test if the release-branch-tests.yml workflow is working as expected. This should be reverted before merging.
     secrets: inherit


### PR DESCRIPTION
resolves #344 

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->

### Description
Recently, we released support to test only the latest two ⁠*.latest branches to ensure we are only testing the most recent two branches for release.

However, [dbt-common](https://github.com/dbt-labs/dbt-common) didn't have any branches with the ⁠*.latest pattern, which broke the scheduled release testing.

For ⁠dbt-common, we only need to test the ⁠main branch as part of the scheduled testing. Hence, we've introduced a ⁠branch override ability, where only the specified override branches are tested if provided. This will ensure reusability for future changes where such unique requirements need to be accommodated.

### Actions Test Run 
dbt Common Successful Workflow - https://github.com/dbt-labs/dbt-common/actions/runs/21128243632
dbt Core Successful Workflow - https://github.com/dbt-labs/dbt-core/actions/runs/21128319427

> [Dependent PR ](https://github.com/dbt-labs/actions/pull/235) needs to be merged before merging this PR

<!---
  Describe the Pull Request here. Add any references and info to help reviewers
  understand your changes. Include any tradeoffs you considered.
-->

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-common/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [ ] I ~~have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-common/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)~~
 
