### PR TITLE
add error deferral mechanism to event manager

### DIFF
--- a/.changes/unreleased/Features-20260421-024257.yaml
+++ b/.changes/unreleased/Features-20260421-024257.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Add event deferral capability to EventManager
+time: 2026-04-21T02:42:57.122492+05:30
+custom:
+    Author: ash2shukla
+    Issue: "12339"

--- a/dbt_common/events/base_types.py
+++ b/dbt_common/events/base_types.py
@@ -42,6 +42,13 @@ class EventLevel(str, Enum):
     ERROR = "error"
 
 
+class EventGroupType(Enum):
+    """Deferred events can be grouped by type"""
+
+    DEFAULT = "default"
+    PARSE = "parse"
+
+
 class BaseEvent:
     """BaseEvent for proto message generated python events."""
 

--- a/dbt_common/events/event_manager.py
+++ b/dbt_common/events/event_manager.py
@@ -1,11 +1,25 @@
 import os
 import traceback
-from typing import Any, List, Optional, Protocol, Tuple, Union
+from collections import defaultdict
+from typing import Any, List, Optional, Protocol, Tuple, Union, DefaultDict, NamedTuple
 
-from dbt_common.events.base_types import BaseEvent, EventLevel, msg_from_base_event, TCallback
+from dbt_common.events.base_types import (
+    BaseEvent,
+    EventLevel,
+    msg_from_base_event,
+    TCallback,
+    EventGroupType,
+)
 from dbt_common.events.logger import LoggerConfig, _Logger, _TextLogger, _JsonLogger, LineFormat
 from dbt_common.exceptions.events import EventCompilationError
 from dbt_common.helper_types import WarnErrorOptions, WarnErrorOptionsV2
+
+
+class FireEventArgs(NamedTuple):
+    event: BaseEvent
+    level: Optional[EventLevel]
+    node: Any
+    force_warn_or_error_handling: bool
 
 
 class EventManager:
@@ -14,7 +28,11 @@ class EventManager:
         self.callbacks: List[TCallback] = []
         self._warn_error: Optional[bool] = None
         self._warn_error_options: Optional[Union[WarnErrorOptions, WarnErrorOptionsV2]] = None
+        self._deferred_event_groups: DefaultDict[
+            EventGroupType, List[FireEventArgs]
+        ] = defaultdict(list)
         self.require_warn_or_error_handling: bool = False
+        self.allow_deferral: bool = False
 
     @property
     def warn_error(self) -> bool:
@@ -96,6 +114,46 @@ class EventManager:
         for logger in self.loggers:
             logger.flush()
 
+    def fire_or_defer_event(
+        self,
+        e: BaseEvent,
+        event_group_type: EventGroupType = EventGroupType.DEFAULT,
+        level: Optional[EventLevel] = None,
+        node: Any = None,
+        force_warn_or_error_handling: bool = False,
+    ) -> None:
+        if self.allow_deferral:
+            args = FireEventArgs(
+                event=e,
+                level=level,
+                node=node,
+                force_warn_or_error_handling=force_warn_or_error_handling,
+            )
+            self._deferred_event_groups[event_group_type].append(args)
+        else:
+            self.fire_event(e, level, node, force_warn_or_error_handling)
+
+    def _summarize_raised_events(self, event_group_type: EventGroupType) -> Optional[str]:
+        event_args = self._deferred_event_groups.pop(event_group_type, [])
+        raised_events = []
+
+        for e in event_args:
+            try:
+                self.fire_event(e.event, e.level, e.node, e.force_warn_or_error_handling)
+            except EventCompilationError:
+                raised_events.append(e.event)
+
+        if raised_events:
+            summary = "\n".join(e.message() for e in raised_events)
+            return summary
+
+    def fire_deferred_events(
+        self, event_group_type: EventGroupType = EventGroupType.DEFAULT
+    ) -> None:
+        events_summary = self._summarize_raised_events(event_group_type)
+        if events_summary is not None:
+            raise EventCompilationError(events_summary, None)
+
 
 class IEventManager(Protocol):
     callbacks: List[TCallback]
@@ -140,4 +198,7 @@ class TestEventManager(IEventManager):
         self.event_history.append((e, level))
 
     def add_logger(self, config: LoggerConfig) -> None:
+        raise NotImplementedError()
+
+    def add_callback(self, callback: TCallback) -> None:
         raise NotImplementedError()

--- a/dbt_common/events/event_manager.py
+++ b/dbt_common/events/event_manager.py
@@ -133,7 +133,7 @@ class EventManager:
         else:
             self.fire_event(e, level, node, force_warn_or_error_handling)
 
-    def _summarize_raised_events(self, event_group_type: EventGroupType) -> Optional[str]:
+    def _fire_and_summarize_raised_events(self, event_group_type: EventGroupType) -> Optional[str]:
         event_args = self._deferred_event_groups.pop(event_group_type, [])
         raised_events = []
 
@@ -150,7 +150,7 @@ class EventManager:
     def fire_deferred_events(
         self, event_group_type: EventGroupType = EventGroupType.DEFAULT
     ) -> None:
-        events_summary = self._summarize_raised_events(event_group_type)
+        events_summary = self._fire_and_summarize_raised_events(event_group_type)
         if events_summary is not None:
             raise EventCompilationError(events_summary, None)
 

--- a/tests/unit/test_event_manager.py
+++ b/tests/unit/test_event_manager.py
@@ -1,7 +1,20 @@
+import pytest
+
+from dbt_common.events.base_types import EventGroupType
 from dbt_common.events.event_catcher import EventCatcher
 from dbt_common.events.event_manager import EventManager
-from dbt_common.events.types import BehaviorChangeEvent
+from dbt_common.events.types import BehaviorChangeEvent, GetMetaKeyWarning
+from dbt_common.exceptions.events import EventCompilationError
 from dbt_common.helper_types import WarnErrorOptionsV2
+
+
+def _make_event(description: str = "test") -> BehaviorChangeEvent:
+    return BehaviorChangeEvent(
+        flag_name="test",
+        flag_source="test",
+        description=description,
+        docs_url="test",
+    )
 
 
 class TestEventManager:
@@ -37,3 +50,172 @@ class TestEventManagerSilencedDeprecation:
         event_manager.warn_error_options.silence.append("Deprecations")
         event_manager.fire_event(e=event, force_warn_or_error_handling=True)
         assert len(event_catcher.caught_events) == 0
+
+
+class TestFireOrDeferEvent:
+    def test_fires_immediately_when_deferral_disabled(self) -> None:
+        catcher = EventCatcher()
+        em = EventManager()
+        em.add_callback(catcher.catch)
+
+        em.fire_or_defer_event(_make_event(), EventGroupType.PARSE)
+
+        assert len(catcher.caught_events) == 1
+        assert em._deferred_event_groups[EventGroupType.PARSE] == []
+
+    def test_queues_event_when_deferral_enabled(self) -> None:
+        catcher = EventCatcher()
+        em = EventManager()
+        em.add_callback(catcher.catch)
+        em.allow_deferral = True
+
+        em.fire_or_defer_event(_make_event(), EventGroupType.PARSE)
+
+        assert len(catcher.caught_events) == 0
+        assert len(em._deferred_event_groups[EventGroupType.PARSE]) == 1
+
+    def test_preserves_fire_event_args_on_defer(self) -> None:
+        em = EventManager()
+        em.allow_deferral = True
+        evt = _make_event()
+
+        em.fire_or_defer_event(
+            evt,
+            EventGroupType.PARSE,
+            level=None,
+            node="my_node",
+            force_warn_or_error_handling=True,
+        )
+
+        (queued,) = em._deferred_event_groups[EventGroupType.PARSE]
+        assert queued.event is evt
+        assert queued.node == "my_node"
+        assert queued.force_warn_or_error_handling is True
+
+
+class TestFireDeferredEvents:
+    def test_aggregates_warn_errors_into_single_exception(self) -> None:
+        em = EventManager()
+        em.warn_error = True
+        em.allow_deferral = True
+
+        em.fire_or_defer_event(
+            _make_event("first warning"),
+            EventGroupType.PARSE,
+            force_warn_or_error_handling=True,
+        )
+        em.fire_or_defer_event(
+            _make_event("second warning"),
+            EventGroupType.PARSE,
+            force_warn_or_error_handling=True,
+        )
+
+        with pytest.raises(EventCompilationError) as exc_info:
+            em.fire_deferred_events(EventGroupType.PARSE)
+
+        msg = str(exc_info.value)
+        assert "first warning" in msg
+        assert "second warning" in msg
+
+    def test_drains_group_after_flush(self) -> None:
+        em = EventManager()
+        em.warn_error = True
+        em.allow_deferral = True
+        em.fire_or_defer_event(
+            _make_event(),
+            EventGroupType.PARSE,
+            force_warn_or_error_handling=True,
+        )
+
+        with pytest.raises(EventCompilationError):
+            em.fire_deferred_events(EventGroupType.PARSE)
+
+        assert em._deferred_event_groups[EventGroupType.PARSE] == []
+
+    def test_non_raising_events_still_delivered_to_callbacks(self) -> None:
+        catcher = EventCatcher()
+        em = EventManager()
+        em.add_callback(catcher.catch)
+        em.allow_deferral = True
+
+        em.fire_or_defer_event(_make_event(), EventGroupType.PARSE)
+        em.fire_deferred_events(EventGroupType.PARSE)
+
+        assert len(catcher.caught_events) == 1
+
+    def test_groups_are_isolated(self) -> None:
+        em = EventManager()
+        em.warn_error = True
+        em.allow_deferral = True
+
+        em.fire_or_defer_event(
+            _make_event("first"),
+            EventGroupType.PARSE,
+            force_warn_or_error_handling=True,
+        )
+        with pytest.raises(EventCompilationError):
+            em.fire_deferred_events(EventGroupType.PARSE)
+
+        em.fire_or_defer_event(_make_event("second"), EventGroupType.PARSE)
+        assert len(em._deferred_event_groups[EventGroupType.PARSE]) == 1
+        assert em._deferred_event_groups[EventGroupType.PARSE][0].event.description == "second"
+
+    def test_does_not_raise_when_nothing_errored(self) -> None:
+        em = EventManager()
+        em.fire_deferred_events(EventGroupType.PARSE)
+
+    def test_respects_warn_error_options_across_event_types(self) -> None:
+        catcher = EventCatcher()
+        em = EventManager()
+        em.add_callback(catcher.catch)
+        em.warn_error_options = WarnErrorOptionsV2(
+            error=["BehaviorChangeEvent"],
+            silence=["GetMetaKeyWarning"],
+            valid_error_names={"BehaviorChangeEvent", "GetMetaKeyWarning"},
+        )
+        em.allow_deferral = True
+
+        errored = _make_event("migration required")
+        silenced = GetMetaKeyWarning(meta_key="my_key")
+
+        em.fire_or_defer_event(errored, EventGroupType.PARSE, force_warn_or_error_handling=True)
+        em.fire_or_defer_event(silenced, EventGroupType.PARSE, force_warn_or_error_handling=True)
+
+        with pytest.raises(EventCompilationError) as exc_info:
+            em.fire_deferred_events(EventGroupType.PARSE)
+
+        msg = str(exc_info.value)
+        assert "migration required" in msg
+        assert "my_key" not in msg
+        caught_names = {ev.info.name for ev in catcher.caught_events}
+        assert "GetMetaKeyWarning" not in caught_names
+
+
+class TestDefaultEventGroup:
+    def test_default_group_used_when_unspecified(self) -> None:
+        em = EventManager()
+        em.allow_deferral = True
+
+        em.fire_or_defer_event(_make_event())
+
+        assert len(em._deferred_event_groups[EventGroupType.DEFAULT]) == 1
+        assert em._deferred_event_groups[EventGroupType.PARSE] == []
+
+    def test_default_group_flushes_independently_of_parse(self) -> None:
+        em = EventManager()
+        em.warn_error = True
+        em.allow_deferral = True
+
+        em.fire_or_defer_event(_make_event("default group"), force_warn_or_error_handling=True)
+        em.fire_or_defer_event(
+            _make_event("parse group"),
+            EventGroupType.PARSE,
+            force_warn_or_error_handling=True,
+        )
+
+        with pytest.raises(EventCompilationError) as exc_info:
+            em.fire_deferred_events()
+
+        assert "default group" in str(exc_info.value)
+        assert "parse group" not in str(exc_info.value)
+        assert len(em._deferred_event_groups[EventGroupType.PARSE]) == 1


### PR DESCRIPTION
resolves #12339

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->

### Description
Adds a event group based error deferral mechanism to event manager.
- Define event group types eg. default, parse, compile etc.
- Provides a mechanism to defer or fire the events through `fire_or_defer_event` function
- Provides another method to raise these collect event groups through `fire_deferred_events` function

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-common/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-common/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
 
