### PR TITLE
ci: pin dbt-core test ref to 1.latest

### DIFF
--- a/.github/workflows/ci_dbt_core_testing.yml
+++ b/.github/workflows/ci_dbt_core_testing.yml
@@ -16,7 +16,7 @@ name: "dbt-core Tests"
 run-name: >-
   ${{ (github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call')
   && format('dbt-core@{0} with dbt-common@{1}', inputs.dbt-core-ref, inputs.dbt-common-ref)
-  || 'dbt-core@main with dbt-common branch' }}
+  || 'dbt-core@1.latest with dbt-common branch' }}
 
 on:
   merge_group:
@@ -26,7 +26,7 @@ on:
     inputs:
       dbt-core-ref:
         description: "The branch of dbt-core to test against"
-        default: "main"
+        default: "1.latest"
       dbt-common-ref:
         description: "The branch of dbt-common to test against"
         default: "main"
@@ -36,7 +36,7 @@ on:
         description: "The branch of dbt-core to test against"
         type: string
         required: true
-        default: "main"
+        default: "1.latest"
       dbt-common-ref:
         description: "The branch of dbt-common to test against"
         type: string
@@ -82,7 +82,7 @@ jobs:
         id: core-ref
         run: |
           if [[ -z "${{ inputs.dbt-core-ref }}" ]]; then
-            REF="main"
+            REF="1.latest"
           else
             REF=${{ inputs.dbt-core-ref }}
           fi

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The shared common utilities for dbt-core and adapter implementations use
 To release a new version of dbt-common to pypi, you'll need to: 
 1. Run the [release workflow](https://github.com/dbt-labs/dbt-common/actions/workflows/release.yml) to bump the version, generate changelogs and release to pypi
 4. Bump the version of `dbt-common` in `dbt-core` and `dbt-adapters` if you're releasing a new major version or a pre-release: 
-   * `dbt-core`: [setup.py](https://github.com/dbt-labs/dbt-core/blob/main/core/setup.py)
+   * `dbt-core`: [setup.py](https://github.com/dbt-labs/dbt-core/blob/1.latest/core/setup.py)
    * `dbt-adapters`: [pyproject.toml](https://github.com/dbt-labs/dbt-adapters/blob/main/pyproject.toml)
    * Adapter Implementations: 
      * `dbt-postgres`: [pyproject.toml](https://github.com/dbt-labs/dbt-postgres/blob/main/pyproject.toml)


### PR DESCRIPTION
## Summary
- Switch every dbt-core branch reference from `main` to `1.latest` so dbt-common CI tracks the latest 1.x release branch of dbt-core instead of `main`.
- Updates apply to `dbt-core-ref` defaults for `workflow_dispatch` and `workflow_call`, the shell fallback in the `Determine dbt-core ref` step, the `run-name` fallback shown for PR / merge_group runs, and the README link to `dbt-core/core/setup.py`.

## Test plan
- [x] [Trigger](https://github.com/dbt-labs/dbt-common/actions/runs/26506986866) `ci_dbt_core_testing.yml` via `workflow_dispatch` with no inputs and confirm the run name shows `dbt-core@1.latest` and the checkout pulls dbt-core's `1.latest` branch.
🤖 Generated with [Claude Code](https://claude.com/claude-code)