### PR TITLE
Add OpenTelemetry context propagation support for executors

### DIFF
--- a/.changes/unreleased/Features-20250514-120000.yaml
+++ b/.changes/unreleased/Features-20250514-120000.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Add OpenTelemetry context propagation support for thread pool executors
+time: 2025-05-14T12:00:00.000000-07:00
+custom:
+    Author: sfc-gh-vguttha
+    Issue: "11367"

--- a/dbt_common/context.py
+++ b/dbt_common/context.py
@@ -4,6 +4,8 @@ from typing import List, Mapping, Optional, Iterator, Set
 
 from dbt_common.constants import PRIVATE_ENV_PREFIX, SECRET_ENV_PREFIX
 from dbt_common.record import Recorder
+from opentelemetry.context.context import Context
+from opentelemetry import context as opentelemetry_context
 
 
 class CaseInsensitiveMapping(Mapping[str, str]):
@@ -110,3 +112,7 @@ def try_get_invocation_context() -> Optional[InvocationContext]:
         return get_invocation_context()
     except Exception:
         return None
+
+
+def set_otel_context(context: Context):
+    opentelemetry_context.attach(context)

--- a/dbt_common/context.py
+++ b/dbt_common/context.py
@@ -47,6 +47,11 @@ class InvocationContext:
         self.recorder: Optional[Recorder] = None
         self._adapter_types: Set[str] = set()
 
+        # Gates OpenTelemetry instrumentation. Set by dbt-core from the
+        # --snowflake-projects-otel flag; when False, no OTel context is
+        # propagated to worker threads and no spans are emitted.
+        self.enable_snowflake_projects_otel: bool = False
+
         # If set to True later, this flag will prevent dbt from creating a new
         # invocation context for every invocation, which is useful for testing
         # scenarios.
@@ -114,5 +119,5 @@ def try_get_invocation_context() -> Optional[InvocationContext]:
         return None
 
 
-def set_otel_context(context: Context):
+def set_otel_context(context: Context) -> None:
     opentelemetry_context.attach(context)

--- a/dbt_common/utils/executor.py
+++ b/dbt_common/utils/executor.py
@@ -6,7 +6,11 @@ from dbt_common.context import (
     get_invocation_context,
     reliably_get_invocation_var,
     InvocationContext,
+    set_otel_context,
 )
+
+from opentelemetry.context.context import Context
+from opentelemetry import context as opentelemetry_context
 
 
 class ConnectingExecutor(concurrent.futures.Executor):
@@ -66,9 +70,10 @@ class HasThreadingConfig(Protocol):
     threads: Optional[int]
 
 
-def _thread_initializer(invocation_context: InvocationContext) -> None:
+def _thread_initializer(invocation_context: InvocationContext, context: Context) -> None:
     invocation_var = reliably_get_invocation_var()
     invocation_var.set(invocation_context)
+    set_otel_context(context)
 
 
 def executor(config: HasThreadingConfig) -> ConnectingExecutor:
@@ -78,5 +83,5 @@ def executor(config: HasThreadingConfig) -> ConnectingExecutor:
         return MultiThreadedExecutor(
             max_workers=config.threads,
             initializer=_thread_initializer,  # type: ignore
-            initargs=(get_invocation_context(),),  # type: ignore
+            initargs=(get_invocation_context(), opentelemetry_context.get_current()),  # type: ignore
         )

--- a/dbt_common/utils/executor.py
+++ b/dbt_common/utils/executor.py
@@ -70,18 +70,27 @@ class HasThreadingConfig(Protocol):
     threads: Optional[int]
 
 
-def _thread_initializer(invocation_context: InvocationContext, context: Context) -> None:
+def _thread_initializer(
+    invocation_context: InvocationContext, context: Optional[Context] = None
+) -> None:
     invocation_var = reliably_get_invocation_var()
     invocation_var.set(invocation_context)
-    set_otel_context(context)
+    if invocation_context.enable_snowflake_projects_otel and context is not None:
+        set_otel_context(context)
 
 
 def executor(config: HasThreadingConfig) -> ConnectingExecutor:
     if config.args.single_threaded:
         return SingleThreadedExecutor()
     else:
+        invocation_context = get_invocation_context()
+        otel_context = (
+            opentelemetry_context.get_current()
+            if invocation_context.enable_snowflake_projects_otel
+            else None
+        )
         return MultiThreadedExecutor(
             max_workers=config.threads,
             initializer=_thread_initializer,  # type: ignore
-            initargs=(get_invocation_context(), opentelemetry_context.get_current()),  # type: ignore
+            initargs=(invocation_context, otel_context),  # type: ignore
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dependencies = [
   "python-dateutil>=2.0,<3.0",
   "requests<3.0.0",  # needs to match dbt-core
   "typing-extensions>=4.4,<5.0",
+  "opentelemetry-api>=1.26,<3.0",
 ]
 
 [project.optional-dependencies]
@@ -64,6 +65,7 @@ test = [
     "pytest-xdist>=3.2,<4.0",
     "pytest-cov>=4.1,<5.0",
     "hypothesis>=6.87,<7.0",
+    "opentelemetry-sdk>=1.26,<3.0",
 ]
 build = [
     "wheel",

--- a/tests/unit/test_executor.py
+++ b/tests/unit/test_executor.py
@@ -1,0 +1,40 @@
+import pytest
+from opentelemetry import trace
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from dbt_common.utils.executor import executor
+from dbt_common.context import set_invocation_context
+
+
+class ThreadingType:
+    def __init__(self, single_threaded):
+        self.single_threaded = single_threaded
+
+
+class TestConfig:
+    def __init__(self, args, threads=1):
+        self.args = args
+        self.threads = threads
+
+
+@pytest.mark.parametrize("single_threaded, threads", [(False, 2), (True, 1)])
+def test_executor_opentelemetry_context_propagation(single_threaded, threads):
+    tracer_provider = TracerProvider(resource=Resource.get_empty())
+    span_exporter = InMemorySpanExporter()
+    trace.set_tracer_provider(tracer_provider)
+    trace.get_tracer_provider().add_span_processor(SimpleSpanProcessor(span_exporter))
+    tracer = trace.get_tracer("test.dbt.runner")
+    set_invocation_context({})
+    with tracer.start_as_current_span("test-span") as span:
+        config = TestConfig(ThreadingType(single_threaded=single_threaded), threads=threads)
+
+        def func():
+            return trace.get_current_span().get_span_context()
+
+        with executor(config) as ex:
+            future = ex.submit(func)
+            span_context_in_thread = future.result()
+            assert span.get_span_context().trace_id == span_context_in_thread.trace_id
+            assert span.get_span_context().span_id == span_context_in_thread.span_id

--- a/tests/unit/test_executor.py
+++ b/tests/unit/test_executor.py
@@ -5,7 +5,7 @@ from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 from dbt_common.utils.executor import executor
-from dbt_common.context import set_invocation_context
+from dbt_common.context import set_invocation_context, get_invocation_context
 
 
 class ThreadingType:
@@ -27,6 +27,7 @@ def test_executor_opentelemetry_context_propagation(single_threaded, threads):
     trace.get_tracer_provider().add_span_processor(SimpleSpanProcessor(span_exporter))
     tracer = trace.get_tracer("test.dbt.runner")
     set_invocation_context({})
+    get_invocation_context().enable_snowflake_projects_otel = True
     with tracer.start_as_current_span("test-span") as span:
         config = TestConfig(ThreadingType(single_threaded=single_threaded), threads=threads)
 
@@ -38,3 +39,22 @@ def test_executor_opentelemetry_context_propagation(single_threaded, threads):
             span_context_in_thread = future.result()
             assert span.get_span_context().trace_id == span_context_in_thread.trace_id
             assert span.get_span_context().span_id == span_context_in_thread.span_id
+
+
+def test_executor_no_otel_context_propagation_when_disabled():
+    tracer_provider = TracerProvider(resource=Resource.get_empty())
+    span_exporter = InMemorySpanExporter()
+    trace.set_tracer_provider(tracer_provider)
+    trace.get_tracer_provider().add_span_processor(SimpleSpanProcessor(span_exporter))
+    tracer = trace.get_tracer("test.dbt.runner")
+    set_invocation_context({})
+    with tracer.start_as_current_span("test-span") as span:
+        config = TestConfig(ThreadingType(single_threaded=False), threads=2)
+
+        def func():
+            return trace.get_current_span().get_span_context()
+
+        with executor(config) as ex:
+            future = ex.submit(func)
+            span_context_in_thread = future.result()
+            assert span.get_span_context().trace_id != span_context_in_thread.trace_id


### PR DESCRIPTION
resolves #11367

Add opentelemetry-api as a runtime dependency and propagate OTEL context to worker threads so that spans created in executor threads are correctly parented to the calling thread's active span. 

This change has a corresponding change in dbt-core ([PR](https://github.com/dbt-labs/dbt-core/pull/15551))

### Description

- Propagate the active OpenTelemetry context into thread-pool executor worker threads, so spans created off the main thread are parented to the calling thread's active span (dbt_common/utils/executor.py): capture the current context with opentelemetry_context.get_current() and pass it as a thread initargs, then re-attach it in _thread_initializer.
- Context propagation is gated behind an invocation-context flag. dbt-core sets this field from its --snowflake-projects-otel flag
- Add a set_otel_context() helper (dbt_common/context.py) that attaches an OpenTelemetry Context in the current (worker) thread.
- Add opentelemetry-api as a runtime dependency and opentelemetry-sdk as a test dependency.
- Instrument with the OpenTelemetry API only; the embedding process owns the TracerProvider/exporter (no exporter configured in-repo).
- Add a unit test covering OTel context propagation into worker threads (tests/unit/test_executor.py).

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-common/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] I have [opened an issue to add/update docs](https://github.com/dbt-labs/docs.getdbt.com/issues/new/choose), or docs changes are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-common/blob/main/CONTRIBUTING.md#Adding-CHANGELOG-Entry)
 
