### PR TITLE
Fix typos and update Black target-version to match Python requirement

### DIFF
--- a/.changes/unreleased/Under the Hood-20260717-030000.yaml
+++ b/.changes/unreleased/Under the Hood-20260717-030000.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Fix typos in CONTRIBUTING.md and system.py, update Black target-version to match Python >=3.10 requirement
+time: 2026-07-17T03:00:00.000000+05:30
+custom:
+  Author: arijitroy003
+  Issue: "370"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,7 +92,7 @@ Once you're able to manually test that your code change is working as expected, 
 
 See the pyproject.toml for a complete list of custom commands.  See the h[atch docs](https://hatch.pypa.io/latest/cli/reference/) for a description of built in commands and flags.
 
-Run `hatch env show` to view a list of all envoronments and all commands available within them.
+Run `hatch env show` to view a list of all environments and all commands available within them.
 
 Example uses:
 

--- a/dbt_common/clients/system.py
+++ b/dbt_common/clients/system.py
@@ -385,7 +385,7 @@ def _supports_long_paths() -> bool:
     # Eryk Sun says to use `WinDLL('ntdll')` instead of `windll.ntdll` because
     # of pointer caching in a comment here:
     # https://stackoverflow.com/a/35097999/11262881
-    # I don't know exaclty what he means, but I am inclined to believe him as
+    # I don't know exactly what he means, but I am inclined to believe him as
     # he's pretty active on Python windows bugs!
     else:
         try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,7 +117,7 @@ mypy = "python -m mypy ."
 
 [tool.black]
 line-length = 99
-target-version = ['py38']
+target-version = ['py310']
 
 [tool.flake8]
 max-line-length = 99


### PR DESCRIPTION
## Summary

1. CONTRIBUTING.md around line 95: "envoronments" -> "environments"
2. system.py around line 388: "exaclty" -> "exactly"
3. pyproject.toml around line 120: Black target-version is ['py38'] but the project requires Python >=3.10. Change to ['py310'].

## Test plan

- [x] Changes are cosmetic/config only — no behavior change
- [x] Verified patterns exist before fixing